### PR TITLE
Dogfooding - Remove unused private method parameters cleanup for

### DIFF
--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/properties/PropertyManager2.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/properties/PropertyManager2.java
@@ -90,13 +90,13 @@ public class PropertyManager2 implements IPropertyManager {
 
 	@Override
 	public synchronized void copy(IResource source, IResource destination, int depth) throws CoreException {
-		copyProperties(source.getFullPath(), destination.getFullPath(), depth);
+		copyProperties(source.getFullPath(), destination.getFullPath());
 	}
 
 	/**
 	 * Copies all properties from the source path to the target path, to the given depth.
 	 */
-	private void copyProperties(final IPath source, final IPath destination, int depth) throws CoreException {
+	private void copyProperties(final IPath source, final IPath destination) throws CoreException {
 		Assert.isLegal(source.segmentCount() > 0);
 		Assert.isLegal(destination.segmentCount() > 0);
 		Assert.isLegal(source.segmentCount() > 1 || destination.segmentCount() == 1);

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/PathVariableUtil.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/PathVariableUtil.java
@@ -85,7 +85,7 @@ public class PathVariableUtil {
 		if (variableHint != null && pathVariableManager.isDefined(variableHint)) {
 			IPath value = URIUtil.toPath(pathVariableManager.getURIValue(variableHint));
 			if (value != null)
-				return wrapInProperFormat(makeRelativeToVariable(pathVariableManager, originalPath, resource, force, variableHint, generateMacro), generateMacro);
+				return wrapInProperFormat(makeRelativeToVariable(pathVariableManager, originalPath, force, variableHint), generateMacro);
 		}
 		IPath path = convertToProperCase(originalPath);
 		IPath newPath = null;
@@ -110,7 +110,7 @@ public class PathVariableUtil {
 					int matchLength = value.segmentCount();
 					if (matchLength > maxMatchLength) {
 						maxMatchLength = matchLength;
-						newPath = makeRelativeToVariable(pathVariableManager, originalPath, resource, force, variable, generateMacro);
+						newPath = makeRelativeToVariable(pathVariableManager, originalPath, force, variable);
 					}
 				}
 			}
@@ -139,7 +139,7 @@ public class PathVariableUtil {
 							int difference = value.segmentCount() - originalSegmentCount;
 							if (difference < minDifference) {
 								minDifference = difference;
-								newPath = makeRelativeToVariable(pathVariableManager, originalPath, resource, force, variable, generateMacro);
+								newPath = makeRelativeToVariable(pathVariableManager, originalPath, force, variable);
 							}
 						}
 					}
@@ -152,7 +152,7 @@ public class PathVariableUtil {
 				IPath value = URIUtil.toPath(pathVariableManager.getURIValue(variable));
 				value = convertToProperCase(URIUtil.toPath(pathVariableManager.resolveURI(URIUtil.toURI(value))));
 				if (originalPath.isPrefixOf(value))
-					newPath = makeRelativeToVariable(pathVariableManager, originalPath, resource, force, variable, generateMacro);
+					newPath = makeRelativeToVariable(pathVariableManager, originalPath, force, variable);
 				if (newPath != null)
 					return wrapInProperFormat(newPath, generateMacro);
 			}
@@ -169,7 +169,7 @@ public class PathVariableUtil {
 		return newPath;
 	}
 
-	private static IPath makeRelativeToVariable(IPathVariableManager pathVariableManager, IPath originalPath, IResource resource, boolean force, String variableHint, boolean generateMacro) {
+	private static IPath makeRelativeToVariable(IPathVariableManager pathVariableManager, IPath originalPath, boolean force, String variableHint) {
 		IPath path = convertToProperCase(originalPath);
 		IPath value = URIUtil.toPath(pathVariableManager.getURIValue(variableHint));
 		value = convertToProperCase(URIUtil.toPath(pathVariableManager.resolveURI(URIUtil.toURI(value))));

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/ProjectDescriptionReader.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/ProjectDescriptionReader.java
@@ -296,7 +296,7 @@ public class ProjectDescriptionReader extends DefaultHandler implements IModelOb
 				break;
 			case S_PROJECTS :
 				if (elementName.equals(PROJECTS)) {
-					endProjectsElement(elementName);
+					endProjectsElement();
 					state = S_PROJECT_DESC;
 				}
 				break;
@@ -804,7 +804,7 @@ public class ProjectDescriptionReader extends DefaultHandler implements IModelOb
 	/**
 	 * End of an element that is part of a project references list
 	 */
-	private void endProjectsElement(String elementName) {
+	private void endProjectsElement() {
 		// Pop the array list that contains all the referenced project names
 		ArrayList<String> referencedProjects = (ArrayList<String>) objectStack.pop();
 		if (referencedProjects.isEmpty())

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/SaveManager.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/SaveManager.java
@@ -1589,7 +1589,7 @@ public class SaveManager implements IElementInfoFlattener, IManager, IStringPool
 					// new master table must provide greater or equal sequence number for root
 					// throw exception if new value is lower than previous one - we cannot allow to desynchronize master table on disk
 					if (valueInMemory < valueInFile) {
-						String message = getBadSequenceNumberErrorMessage(target, valueInFile, valueInMemory, masterTable, previousMasterTable);
+						String message = getBadSequenceNumberErrorMessage(target, valueInFile, valueInMemory);
 						Assert.isLegal(false, message);
 					}
 				}
@@ -1597,7 +1597,7 @@ public class SaveManager implements IElementInfoFlattener, IManager, IStringPool
 		}
 	}
 
-	private static String getBadSequenceNumberErrorMessage(java.io.File target, int valueInFile, int valueInMemory, MasterTable currentMasterTable, MasterTable previousMasterTable) {
+	private static String getBadSequenceNumberErrorMessage(java.io.File target, int valueInFile, int valueInMemory) {
 		StringBuilder messageBuffer = new StringBuilder();
 		messageBuffer.append("Cannot set lower sequence number for root (previous: "); //$NON-NLS-1$
 		messageBuffer.append(valueInFile);
@@ -1878,7 +1878,7 @@ public class SaveManager implements IElementInfoFlattener, IManager, IStringPool
 	 *    For each interesting project:
 	 *       UTF - interesting project name
 	 */
-	private void writeBuilderPersistentInfo(DataOutputStream output, List<BuilderPersistentInfo> builders, IProgressMonitor monitor) throws IOException {
+	private void writeBuilderPersistentInfo(DataOutputStream output, List<BuilderPersistentInfo> builders) throws IOException {
 		// write the number of builders we are saving
 		int numBuilders = builders.size();
 		output.writeInt(numBuilders);
@@ -2006,7 +2006,7 @@ public class SaveManager implements IElementInfoFlattener, IManager, IStringPool
 						additionalConfigNames);
 
 			// Save the version 2 builders info
-			writeBuilderPersistentInfo(output, builderInfos, subMonitor.newChild(1));
+			writeBuilderPersistentInfo(output, builderInfos);
 
 			// Builder infos of non-active configurations are persisted after the active
 			// configuration's builder infos. So, their trees have to follow the same order.
@@ -2023,7 +2023,7 @@ public class SaveManager implements IElementInfoFlattener, IManager, IStringPool
 			subMonitor.worked(4);
 
 			// Since 3.7: Save the additional builders info
-			writeBuilderPersistentInfo(output, additionalBuilderInfos, subMonitor.newChild(1));
+			writeBuilderPersistentInfo(output, additionalBuilderInfos);
 
 			// Save the configuration names for the builders in the order they were saved
 			for (String string : configNames)
@@ -2078,7 +2078,7 @@ public class SaveManager implements IElementInfoFlattener, IManager, IStringPool
 					additionalConfigNames);
 
 			// Save the version 2 builders info
-			writeBuilderPersistentInfo(output, builderInfos, subMonitor.newChild(2));
+			writeBuilderPersistentInfo(output, builderInfos);
 
 			// Builder infos of non-active configurations are persisted after the active
 			// configuration's builder infos. So, their trees have to follow the same order.
@@ -2096,7 +2096,7 @@ public class SaveManager implements IElementInfoFlattener, IManager, IStringPool
 
 			// Since 3.7: Save the builders info and get the workspace trees associated with
 			// those builders
-			writeBuilderPersistentInfo(output, additionalBuilderInfos, subMonitor.newChild(2));
+			writeBuilderPersistentInfo(output, additionalBuilderInfos);
 
 			// Save configuration names for the builders in the order they were saved
 			for (String string : configNames)


### PR DESCRIPTION
core.resources

JDT introduced a new clean for removing unused private method
parameters, we should use it in our code base to "iron" it out.