### PR TITLE
Bug 479451 - Added a timeout wait to session test

### DIFF
--- a/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/TestUtil.java
+++ b/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/TestUtil.java
@@ -161,6 +161,14 @@ public class TestUtil {
 
 	static Set<Job> runningJobs = new LinkedHashSet<>();
 
+	public static void dumRunnigOrWaitingJobs(String owner) {
+		List<Job> jobs = getRunningOrWaitingJobs(null);
+		if (!jobs.isEmpty()) {
+			String message = "Some job is still running or waiting to run: " + asString(jobs);
+			log(IStatus.INFO, owner, message);
+		}
+	}
+
 	private static void dumpRunningOrWaitingJobs(String owner, List<Job> jobs) {
 		String message = "Some job is still running or waiting to run: " + dumpRunningOrWaitingJobs(jobs);
 		log(IStatus.ERROR, owner, message);
@@ -172,9 +180,15 @@ public class TestUtil {
 		}
 		// clear "old" running jobs, we only remember most recent
 		runningJobs.clear();
-		StringBuilder sb = new StringBuilder();
 		for (Job job : jobs) {
 			runningJobs.add(job);
+		}
+		return asString(jobs);
+	}
+
+	private static String asString(List<Job> jobs) {
+		StringBuilder sb = new StringBuilder();
+		for (Job job : jobs) {
 			sb.append("'").append(job.getName()).append("'/");
 			sb.append(job.getClass().getName());
 			sb.append(", ");

--- a/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug202384.java
+++ b/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug202384.java
@@ -16,8 +16,7 @@ package org.eclipse.core.tests.resources.session;
 import junit.framework.Test;
 import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.AutomatedTests;
-import org.eclipse.core.tests.resources.WorkspaceSessionTest;
+import org.eclipse.core.tests.resources.*;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
 
 /**
@@ -87,7 +86,16 @@ public class TestBug202384 extends WorkspaceSessionTest {
 		try {
 			//correct values should be available if ProjectPreferences got
 			//initialized upon creation
-			assertEquals("2.0", "UTF-8", project.getDefaultCharset(false));
+			String expectedEncoding = "UTF-8";
+			// check with a timeout, in case some initialize operation is slow
+			long timeout = 10_000;
+			long start = System.currentTimeMillis();
+			while (!expectedEncoding.equals(project.getDefaultCharset(false))
+					&& System.currentTimeMillis() - start < timeout) {
+				TestUtil.dumRunnigOrWaitingJobs(getName());
+				TestUtil.waitForJobs(getName(), 500, 1000);
+			}
+			assertEquals("2.0", expectedEncoding, project.getDefaultCharset(false));
 		} catch (CoreException e) {
 			fail("3.0", e);
 		}


### PR DESCRIPTION
This change adds a wait that can timeout to
TestBug202384.testStartWithOpenProject(), in case the sporadic fails
seen in integration builds are due to some still running initialization
job.

Signed-off-by: Simeon Andreev <simeon.danailov.andreev@gmail.com>