### PR TITLE
Trying to make testBuilderDeltaUsingRelaxedRuleBug343256 more stable

### DIFF
--- a/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/RelaxedSchedRuleBuilderTest.java
+++ b/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/RelaxedSchedRuleBuilderTest.java
@@ -17,6 +17,7 @@ package org.eclipse.core.tests.internal.builders;
 import java.io.ByteArrayInputStream;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
+import org.eclipse.core.internal.events.ResourceDelta;
 import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.*;
 import org.eclipse.core.runtime.jobs.*;
@@ -251,6 +252,8 @@ public class RelaxedSchedRuleBuilderTest extends AbstractBuilderTest {
 		// Ensure the builder is instantiated
 		project.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
 
+		waitForContentDescriptionUpdate();
+
 		final TestBarrier tb1 = new TestBarrier(TestBarrier.STATUS_WAIT_FOR_START);
 
 		// Create a builder set a null scheduling rule
@@ -276,7 +279,7 @@ public class RelaxedSchedRuleBuilderTest extends AbstractBuilderTest {
 				tb1.waitForStatus(TestBarrier.STATUS_WAIT_FOR_RUN);
 				try {
 					// Give the resource modification time be queued
-					Thread.sleep(10);
+					Thread.sleep(20);
 				} catch (InterruptedException e) {
 					fail();
 				}
@@ -290,7 +293,8 @@ public class RelaxedSchedRuleBuilderTest extends AbstractBuilderTest {
 				// assert that the delta contains the file foo
 				IResourceDelta delta = getDelta(project);
 				assertNotNull("1.1", delta);
-				assertEquals("1.2.", 1, delta.getAffectedChildren().length);
+				assertEquals("1.2: " + ((ResourceDelta) delta).toDeepDebugString(), 1,
+						delta.getAffectedChildren().length);
 				assertEquals("1.3.", foo, delta.getAffectedChildren()[0].getResource());
 				tb1.setStatus(TestBarrier.STATUS_DONE);
 				return super.build(kind, args, monitor);

--- a/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
+++ b/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.resources;
 
 import java.io.*;
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.attribute.FileTime;
@@ -22,8 +23,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.eclipse.core.filesystem.*;
-import org.eclipse.core.internal.resources.Resource;
-import org.eclipse.core.internal.resources.ValidateProjectEncoding;
+import org.eclipse.core.internal.resources.*;
 import org.eclipse.core.internal.utils.FileUtil;
 import org.eclipse.core.internal.utils.UniversalUniqueIdentifier;
 import org.eclipse.core.resources.*;
@@ -1047,5 +1047,9 @@ public abstract class ResourceTest extends CoreTest {
 
 	protected void waitForProjectEncodingValidation() {
 		TestUtil.waitForJobs(getName(), 10, 5_000, ValidateProjectEncoding.class);
+	}
+
+	protected void waitForContentDescriptionUpdate() {
+		TestUtil.waitForJobs(getName(), 10, 5_000, ContentDescriptionManager.FAMILY_DESCRIPTION_CACHE_FLUSH);
 	}
 }


### PR DESCRIPTION
Wait for content description job (that seem to run in parallel) and
slightly increased the time window in which we expect the delta.

Fixes issue #19