### PR TITLE
Bug 352867 multi-threading hardening Workspace.tree / ElementTree

### DIFF
--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Workspace.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Workspace.java
@@ -106,7 +106,7 @@ public class Workspace extends PlatformObject implements IWorkspace, ICoreConsta
 	protected WorkspacePreferences description;
 	protected FileSystemResourceManager fileSystemManager;
 	protected final CopyOnWriteArrayList<ILifecycleListener> lifecycleListeners = new CopyOnWriteArrayList<>();
-	protected LocalMetaArea localMetaArea;
+	protected final LocalMetaArea localMetaArea;
 	/**
 	 * Helper class for performing validation of resource names and locations.
 	 */
@@ -2160,8 +2160,12 @@ public class Workspace extends PlatformObject implements IWorkspace, ICoreConsta
 	 * modifications to the tree.
 	 */
 	public ElementTree newWorkingTree() {
-		tree = tree.newEmptyDelta();
-		return tree;
+		// synchronized for atomic swap. Should have already synchronized by
+		// getWorkManager().checkIn/checkout, but it's not guaranteed
+		synchronized (this) {
+			tree = tree.newEmptyDelta();
+			return tree;
+		}
 	}
 
 	/**

--- a/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/watson/ElementTreeSerializationTest.java
+++ b/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/watson/ElementTreeSerializationTest.java
@@ -44,6 +44,8 @@ public abstract class ElementTreeSerializationTest implements IPathConstants {
 		public void run() {
 			try {
 				doWrite(fWriter, fDataOutputStream);
+				// inform reader, writing is finished:
+				fDataOutputStream.flush(); // DeltaChainFlatteningTest 30s -> 0s
 			} catch (IOException e) {
 				e.printStackTrace();
 				fail("Error writing delta");
@@ -191,8 +193,8 @@ public abstract class ElementTreeSerializationTest implements IPathConstants {
 			readerThread.setStream(ois);
 			writerThread.setWriter(w);
 			readerThread.setReader(r);
-			Thread thread1 = new Thread(writerThread);
-			Thread thread2 = new Thread(readerThread);
+			Thread thread1 = new Thread(writerThread, "testwriter");
+			Thread thread2 = new Thread(readerThread, "testreader");
 			thread1.start();
 			thread2.start();
 			while (thread2.isAlive()) {


### PR DESCRIPTION
* unify SaveManager.sortTrees and ElementTreeWriter.sortTrees to have a
single sort implementation,
* added some missing volatile/final/synchronized
* improved errormessage, if it should still occur.
* added junit for sorting

Signed-off-by: Joerg Kubitz <jkubitz-eclipse@gmx.de>