### PR TITLE
Bug 35286 - throw IOException instead of NPE when sorting trees failed

### DIFF
--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/SaveManager.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/SaveManager.java
@@ -1508,8 +1508,9 @@ public class SaveManager implements IElementInfoFlattener, IManager, IStringPool
 	 *              ElementTreess have the newest ElementTree as ancestor
 	 *              (transitive parent). The given trees do not need to contain all
 	 *              ElementTrees from the getParent() relationship.
-	 * @return trees ordered by ElementTree.treeStamp descending. i.e. newest
-	 *         ElementTree (without ancestor within the trees) first.
+	 * @return null or trees ordered by ElementTree.treeStamp descending. i.e.
+	 *         newest ElementTree (without ancestor within the trees) first. Returns
+	 *         null when the preconditions for sorting are not met.
 	 */
 	public static ElementTree[] sortTrees(ElementTree[] trees) {
 		int numTrees = trees.length;

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/watson/ElementTreeWriter.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/watson/ElementTreeWriter.java
@@ -79,11 +79,17 @@ public class ElementTreeWriter {
 	}
 
 	/**
-	 * Sorts the given array of trees and The sort order is written to the given
-	 * output stream.
+	 * Writes indexes of sorted trees to output stream.
+	 *
+	 * @return sorted array of trees.
+	 * @throws IOException if sorting can not be done.
+	 * @see SaveManager#sortTrees
 	 */
-	protected ElementTree[] sortTrees(ElementTree[] trees, DataOutput output) throws IOException {
+	protected ElementTree[] writeSortedTrees(ElementTree[] trees, DataOutput output) throws IOException {
 		ElementTree[] sorted = SaveManager.sortTrees(trees);
+		if (sorted == null) {
+			throw new IOException("Trees in ambiguous order (Bug 35286)"); //$NON-NLS-1$
+		}
 
 		// compute indexes from sorted elements:
 		int numTrees = trees.length;
@@ -157,7 +163,7 @@ public class ElementTreeWriter {
 		 * Sort the trees in ancestral order,
 		 * which writes the tree order to the output
 		 */
-		ElementTree[] sortedTrees = sortTrees(trees, output);
+		ElementTree[] sortedTrees = writeSortedTrees(trees, output);
 
 		/* Write the complete tree */
 		writeTree(sortedTrees[0], path, depth, output);


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.resources/pull/34#pullrequestreview-939631237