### PR TITLE
add trace option for delta tree details that cause rebuilds

### DIFF
--- a/bundles/org.eclipse.core.resources/.options
+++ b/bundles/org.eclipse.core.resources/.options
@@ -34,6 +34,10 @@ org.eclipse.core.resources/build/cycle=false
 # and because of changes in which project.
 org.eclipse.core.resources/build/needbuild=false
 
+# For incremental builds, print all delta tree nodes that cause a builder to run.
+# Requires org.eclipse.core.resources/build/needbuild=true
+org.eclipse.core.resources/build/needbuilddelta=false
+
 # Prints a stack trace every time an operation finishes that requires a build
 org.eclipse.core.resources/build/needbuildstack=false
 

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/utils/Policy.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/utils/Policy.java
@@ -38,6 +38,7 @@ public class Policy {
 			DEBUG_BUILD_INTERRUPT = DEBUG && options.getBooleanOption(ResourcesPlugin.PI_RESOURCES + "/build/interrupt", false); //$NON-NLS-1$
 			DEBUG_BUILD_INVOKING = DEBUG && options.getBooleanOption(ResourcesPlugin.PI_RESOURCES + "/build/invoking", false); //$NON-NLS-1$
 			DEBUG_BUILD_NEEDED = DEBUG && options.getBooleanOption(ResourcesPlugin.PI_RESOURCES + "/build/needbuild", false); //$NON-NLS-1$
+			DEBUG_BUILD_NEEDED_DELTA = DEBUG && options.getBooleanOption(ResourcesPlugin.PI_RESOURCES + "/build/needbuilddelta", false); //$NON-NLS-1$
 			DEBUG_BUILD_NEEDED_STACK = DEBUG && options.getBooleanOption(ResourcesPlugin.PI_RESOURCES + "/build/needbuildstack", false); //$NON-NLS-1$
 			DEBUG_BUILD_STACK = DEBUG && options.getBooleanOption(ResourcesPlugin.PI_RESOURCES + "/build/stacktrace", false); //$NON-NLS-1$
 
@@ -80,6 +81,7 @@ public class Policy {
 	public static boolean DEBUG_BUILD_INTERRUPT = false;
 	public static boolean DEBUG_BUILD_INVOKING = false;
 	public static boolean DEBUG_BUILD_NEEDED = false;
+	public static boolean DEBUG_BUILD_NEEDED_DELTA = false;
 	public static boolean DEBUG_BUILD_NEEDED_STACK = false;
 	public static boolean DEBUG_BUILD_STACK = false;
 


### PR DESCRIPTION
When builders are detected to need a build, the interesting project name
found in the delta tree may not be enough information. Sometimes, each
interesting modified resource is necessary to see what's going on.

For me, it was necessary to see that only the project resource was modified (touched) to identify ssi-schaefer/lcdsl/pull/56.