### PR TITLE
fix some multithreading issues in Resource Notification

### DIFF
--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/MarkerManager.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/MarkerManager.java
@@ -17,6 +17,7 @@ package org.eclipse.core.internal.resources;
 
 import java.io.*;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
 import org.eclipse.core.internal.localstore.SafeChunkyInputStream;
 import org.eclipse.core.internal.localstore.SafeFileInputStream;
 import org.eclipse.core.internal.utils.Messages;
@@ -35,12 +36,12 @@ public class MarkerManager implements IManager {
 	private static final MarkerInfo[] NO_MARKER_INFO = new MarkerInfo[0];
 	private static final IMarker[] NO_MARKERS = new IMarker[0];
 	protected MarkerTypeDefinitionCache cache = new MarkerTypeDefinitionCache();
-	private long changeId = 0;
-	protected Map<IPath, MarkerSet> currentDeltas = null;
+	private final AtomicLong changeId = new AtomicLong();
+	protected volatile Map<IPath, MarkerSet> currentDeltas = null;
 	protected final MarkerDeltaManager deltaManager = new MarkerDeltaManager();
 
-	protected Workspace workspace;
-	protected MarkerWriter writer = new MarkerWriter(this);
+	protected final Workspace workspace;
+	protected final MarkerWriter writer = new MarkerWriter(this);
 
 	/**
 	 * Creates a new marker manager
@@ -221,9 +222,9 @@ public class MarkerManager implements IManager {
 	protected void changedMarkers(IResource resource, IMarkerSetElement[] changes) {
 		if (changes == null || changes.length == 0)
 			return;
-		changeId++;
+		long change = changeId.incrementAndGet();
 		if (currentDeltas == null)
-			currentDeltas = deltaManager.newGeneration(changeId);
+			currentDeltas = deltaManager.newGeneration(change);
 		IPath path = resource.getFullPath();
 		MarkerSet previousChanges = currentDeltas.get(path);
 		MarkerSet result = MarkerDelta.merge(previousChanges, changes);
@@ -297,7 +298,7 @@ public class MarkerManager implements IManager {
 	}
 
 	public long getChangeId() {
-		return changeId;
+		return changeId.get();
 	}
 
 	/**

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/SaveManager.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/SaveManager.java
@@ -2153,11 +2153,11 @@ public class SaveManager implements IElementInfoFlattener, IManager, IStringPool
 
 	protected void writeWorkspaceFields(DataOutputStream output, IProgressMonitor monitor) throws IOException {
 		// save the next node id
-		output.writeLong(workspace.nextNodeId);
+		output.writeLong(workspace.nextNodeId.get());
 		// save the modification stamp (no longer used)
 		output.writeLong(0L);
 		// save the marker id counter
-		output.writeLong(workspace.nextMarkerId);
+		output.writeLong(workspace.nextMarkerId.get());
 		// save the registered sync partners in the synchronizer
 		((Synchronizer) workspace.getSynchronizer()).savePartners(output);
 	}

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Workspace.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Workspace.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
@@ -118,8 +119,8 @@ public class Workspace extends PlatformObject implements IWorkspace, ICoreConsta
 	protected IMoveDeleteHook moveDeleteHook = null;
 	protected NatureManager natureManager;
 	protected FilterTypeManager filterManager;
-	protected long nextMarkerId = 0;
-	protected long nextNodeId = 1;
+	protected final AtomicLong nextMarkerId = new AtomicLong();
+	protected final AtomicLong nextNodeId = new AtomicLong(1L);
 
 	protected NotificationManager notificationManager;
 	protected boolean openFlag = false;
@@ -2172,11 +2173,11 @@ public class Workspace extends PlatformObject implements IWorkspace, ICoreConsta
 	 * Returns the next, previously unassigned, marker id.
 	 */
 	protected long nextMarkerId() {
-		return nextMarkerId++;
+		return nextMarkerId.getAndIncrement();
 	}
 
 	protected long nextNodeId() {
-		return nextNodeId++;
+		return nextNodeId.getAndIncrement();
 	}
 
 	/**

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/WorkspaceTreeReader_1.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/WorkspaceTreeReader_1.java
@@ -259,11 +259,11 @@ public class WorkspaceTreeReader_1 extends WorkspaceTreeReader {
 		monitor = Policy.monitorFor(monitor);
 		try {
 			// read the node id
-			workspace.nextNodeId = input.readLong();
+			workspace.nextNodeId.set(input.readLong());
 			// read the modification stamp (no longer used)
 			input.readLong();
 			// read the next marker id
-			workspace.nextMarkerId = input.readLong();
+			workspace.nextMarkerId.set(input.readLong());
 			// read the synchronizer's registered sync partners
 			((Synchronizer) workspace.getSynchronizer()).readPartners(input);
 		} finally {


### PR DESCRIPTION
* adding missing final, volatile modifiers
* use of AtomicLong for IDs
* ResourceChangeListenerList uses CopyOnWriteArrayList

The javadoc of ResourceChangeListenerList.getListeners() was wrong:
subsequent adds of same listener (with different modifier) would have
changed the inside of the array.