### PR TITLE
Bug 516583 - Use UTF-8 as default encoding for *new* workspaces

### DIFF
--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/LocalMetaArea.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/LocalMetaArea.java
@@ -265,6 +265,10 @@ public class LocalMetaArea implements ICoreConstants {
 		return metaAreaLocation.toFile().exists() || getBackupLocationFor(metaAreaLocation).toFile().exists();
 	}
 
+	public boolean hasSavedProjects() {
+		return projectMetaLocation.toFile().exists();
+	}
+
 	/**
 	 * Returns the local file system location in which the meta data for the
 	 * resource with the given path is stored.

--- a/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
+++ b/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
@@ -325,6 +325,9 @@ public class CharsetTest extends ResourceTest {
 		try {
 			root.setDefaultCharset(null);
 			assertNull("1.0", root.getDefaultCharset(false));
+
+			root.setDefaultCharset(null, new NullProgressMonitor());
+			assertNull("1.0", root.getDefaultCharset(false));
 		} finally {
 			if (originalUserCharset != null) {
 				root.setDefaultCharset(originalUserCharset);

--- a/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/AllTests.java
+++ b/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/AllTests.java
@@ -28,6 +28,8 @@ import org.junit.runners.Suite;
 		Bug_266907.class, TestBug297635.class, TestBug323833.class,
 		org.eclipse.core.tests.resources.regression.TestMultipleBuildersOfSameType.class,
 		org.eclipse.core.tests.resources.usecase.SnapshotTest.class, ProjectDescriptionDynamicTest.class,
-		TestBug202384.class, TestBug369177.class, TestBug316182.class, TestBug294854.class, TestBug426263.class })
+		TestBug202384.class, TestBug369177.class, TestBug316182.class, TestBug294854.class, TestBug426263.class,
+		TestWorkspaceEncodingExistingWorkspace.class, TestWorkspaceEncodingNewWorkspace.class,
+		TestWorkspaceEncodingWithJvmArgs.class, TestWorkspaceEncodingWithPluginCustomization.class, })
 public class AllTests {
 }

--- a/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestWorkspaceEncodingExistingWorkspace.java
+++ b/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestWorkspaceEncodingExistingWorkspace.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Andrey Loskutov <loskutov@gmx.de> and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Andrey Loskutov <loskutov@gmx.de> - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.core.tests.resources.session;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import junit.framework.Test;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.tests.resources.AutomatedTests;
+import org.eclipse.core.tests.resources.WorkspaceSessionTest;
+import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+
+/**
+ * Tests that explicit workspace encoding not set if there are projects defined
+ */
+public class TestWorkspaceEncodingExistingWorkspace extends WorkspaceSessionTest {
+
+	public static Test suite() {
+		WorkspaceSessionTestSuite suite = new WorkspaceSessionTestSuite(AutomatedTests.PI_RESOURCES_TESTS,
+				TestWorkspaceEncodingExistingWorkspace.class);
+		Path wspRoot = suite.getInstanceLocation().toFile().toPath();
+		Path projectsTree = wspRoot.resolve(".metadata/.plugins/org.eclipse.core.resources/.projects");
+		try {
+			Files.createDirectories(projectsTree);
+		} catch (IOException e) {
+			fail("Unable to create directories: " + projectsTree, e);
+		}
+		return suite;
+	}
+
+	public TestWorkspaceEncodingExistingWorkspace() {
+		super();
+	}
+
+	public void testExpectedEncoding1() throws Exception {
+		String defaultValue = System.getProperty("file.encoding");
+		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+
+		// Should be system default
+		assertEquals(defaultValue, ResourcesPlugin.getEncoding());
+		assertEquals(defaultValue, workspace.getRoot().getDefaultCharset(true));
+
+		// and not defined in workspace
+		String charset = workspace.getRoot().getDefaultCharset(false);
+		assertEquals(null, charset);
+	}
+
+}

--- a/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestWorkspaceEncodingNewWorkspace.java
+++ b/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestWorkspaceEncodingNewWorkspace.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Andrey Loskutov <loskutov@gmx.de> and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Andrey Loskutov <loskutov@gmx.de> - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.core.tests.resources.session;
+
+import junit.framework.Test;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.tests.resources.AutomatedTests;
+import org.eclipse.core.tests.resources.WorkspaceSessionTest;
+import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+
+/**
+ * Tests that encoding is set to UTF-8 in an empty workspace and only if no
+ * preference set already
+ */
+public class TestWorkspaceEncodingNewWorkspace extends WorkspaceSessionTest {
+
+	private static final String CHARSET = "UTF-16";
+
+	public static Test suite() {
+		WorkspaceSessionTestSuite suite = new WorkspaceSessionTestSuite(AutomatedTests.PI_RESOURCES_TESTS,
+				TestWorkspaceEncodingNewWorkspace.class);
+		// no special setup
+		return suite;
+	}
+
+	public TestWorkspaceEncodingNewWorkspace() {
+		super();
+	}
+
+	public void testExpectedEncoding1() throws Exception {
+		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		String charset = workspace.getRoot().getDefaultCharset(false);
+		// Should be default
+		assertEquals("UTF-8", charset);
+		// Set something else
+		workspace.getRoot().setDefaultCharset(CHARSET, getMonitor());
+		workspace.save(true, getMonitor());
+	}
+
+	public void testExpectedEncoding2() throws Exception {
+		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		String charset = workspace.getRoot().getDefaultCharset(false);
+		// Shouldn't be changed anymore
+		assertEquals(CHARSET, charset);
+	}
+}

--- a/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestWorkspaceEncodingWithJvmArgs.java
+++ b/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestWorkspaceEncodingWithJvmArgs.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Andrey Loskutov <loskutov@gmx.de> and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Andrey Loskutov <loskutov@gmx.de> - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.core.tests.resources.session;
+
+import junit.framework.Test;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.tests.resources.AutomatedTests;
+import org.eclipse.core.tests.resources.WorkspaceSessionTest;
+import org.eclipse.core.tests.session.Setup;
+import org.eclipse.core.tests.session.SetupManager.SetupException;
+import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+
+/**
+ * Tests that encoding is set according to jvm arguments
+ */
+public class TestWorkspaceEncodingWithJvmArgs extends WorkspaceSessionTest {
+
+	private static final String CHARSET = "UTF-16";
+
+	public static Test suite() {
+		WorkspaceSessionTestSuite suite = new WorkspaceSessionTestSuite(AutomatedTests.PI_RESOURCES_TESTS,
+				TestWorkspaceEncodingWithJvmArgs.class);
+		try {
+
+			// add pluginCustomization argument
+			Setup setup = suite.getSetup();
+			setup.setSystemProperty("file.encoding", CHARSET);
+		} catch (SetupException e) {
+			// ignore, the test will fail for us
+		}
+		return suite;
+	}
+
+	public TestWorkspaceEncodingWithJvmArgs() {
+		super();
+	}
+
+	public void testExpectedEncoding() throws Exception {
+		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		// Should be system default
+		assertEquals(CHARSET, ResourcesPlugin.getEncoding());
+		assertEquals(CHARSET, workspace.getRoot().getDefaultCharset(true));
+
+		// and also defined in workspace
+		String charset = workspace.getRoot().getDefaultCharset(false);
+		assertEquals(CHARSET, charset);
+	}
+}

--- a/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestWorkspaceEncodingWithPluginCustomization.java
+++ b/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestWorkspaceEncodingWithPluginCustomization.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Andrey Loskutov <loskutov@gmx.de> and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Andrey Loskutov <loskutov@gmx.de> - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.core.tests.resources.session;
+
+import java.io.*;
+import junit.framework.Test;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.tests.harness.FileSystemHelper;
+import org.eclipse.core.tests.resources.AutomatedTests;
+import org.eclipse.core.tests.resources.WorkspaceSessionTest;
+import org.eclipse.core.tests.session.Setup;
+import org.eclipse.core.tests.session.SetupManager.SetupException;
+import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+
+/**
+ * Tests that encoding is set according to plugin customization
+ */
+public class TestWorkspaceEncodingWithPluginCustomization extends WorkspaceSessionTest {
+
+	private static final String CHARSET = "UTF-16";
+	private static final String FILE_NAME = FileSystemHelper.getTempDir().append("plugin_customization_encoding.ini").toOSString();
+
+	public static Test suite() {
+		WorkspaceSessionTestSuite suite = new WorkspaceSessionTestSuite(AutomatedTests.PI_RESOURCES_TESTS,
+				TestWorkspaceEncodingWithPluginCustomization.class);
+		try {
+			// create plugin_customization.ini file
+			File file = new File(FILE_NAME);
+			try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
+				writer.write("org.eclipse.core.resources/encoding=" + CHARSET);
+			}
+
+			// add pluginCustomization argument
+			Setup setup = suite.getSetup();
+			setup.setEclipseArgument("pluginCustomization", file.toString());
+		} catch (IOException | SetupException e) {
+			// ignore, the test will fail for us
+		}
+		return suite;
+	}
+
+	public TestWorkspaceEncodingWithPluginCustomization() {
+		super();
+	}
+
+	public void testExpectedEncoding() throws Exception {
+		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		// Should be system default
+		assertEquals(CHARSET, ResourcesPlugin.getEncoding());
+		assertEquals(CHARSET, workspace.getRoot().getDefaultCharset(true));
+
+		// and defined in workspace because it is the custom product preference
+		String charset = workspace.getRoot().getDefaultCharset(false);
+		assertEquals(CHARSET, charset);
+	}
+}


### PR DESCRIPTION
Set UTF-8 foor new workspace as default workspace encoding if Eclipse is
started without explicit encoding set (either as JVM system property
-Dfile.encoding=XYZ or by product customization preference
org.eclipse.core.resources/encoding=XYZ).

After that all projects created in this workspace will get explicit
UTF-8 encoding set (they will derive that from the workspace encoding
and not from some random encoding taken from current OS settings).

Existing workspaces or projects with explicit encoding set will be not
affected by the change.

This PR requires https://github.com/eclipse-platform/eclipse.platform.runtime/pull/22 merged first