### PR TITLE
Wake up sleeping jobs before waiting on them

### DIFF
--- a/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug202384.java
+++ b/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug202384.java
@@ -92,7 +92,7 @@ public class TestBug202384 extends WorkspaceSessionTest {
 			long start = System.currentTimeMillis();
 			while (!expectedEncoding.equals(project.getDefaultCharset(false))
 					&& System.currentTimeMillis() - start < timeout) {
-				TestUtil.dumRunnigOrWaitingJobs(getName());
+				TestUtil.dumpRunnigOrWaitingJobs(getName());
 				TestUtil.waitForJobs(getName(), 500, 1000);
 			}
 			assertEquals("2.0", expectedEncoding, project.getDefaultCharset(false));


### PR DESCRIPTION
CharsetDeltaJob.addToQueue(ICharsetListenerFilter) uses timeout of 500
ms before it starts working, so it may awake in the middle of the test.

So if we want to wait for some jobs in the test, we should awake them
first, otherwise they won't be in the running/waiting state if we check
that in waitForJobs() so we will not wait for them at all.

Most likely fixes issue
https://github.com/eclipse-platform/eclipse.platform.resources/issues/42