### PR TITLE
SaveManager access the ResourcesPlugin.getWorkspace at init phase

### DIFF
--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/DelayedSnapshotJob.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/DelayedSnapshotJob.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2014 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,13 +10,13 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Christoph Läubrich - Issue #77 - SaveManager access the ResourcesPlugin.getWorkspace at init phase
  *******************************************************************************/
 package org.eclipse.core.internal.resources;
 
 import org.eclipse.core.internal.utils.Messages;
 import org.eclipse.core.internal.utils.Policy;
 import org.eclipse.core.resources.ISaveContext;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.*;
 import org.eclipse.core.runtime.jobs.Job;
 
@@ -27,11 +27,13 @@ public class DelayedSnapshotJob extends Job {
 
 	private static final String MSG_SNAPSHOT = Messages.resources_snapshot;
 	private SaveManager saveManager;
+	private Workspace workspace;
 
-	public DelayedSnapshotJob(SaveManager manager) {
+	public DelayedSnapshotJob(SaveManager manager, Workspace workspace) {
 		super(MSG_SNAPSHOT);
 		this.saveManager = manager;
-		setRule(ResourcesPlugin.getWorkspace().getRoot());
+		this.workspace = workspace;
+		setRule(workspace.getRoot());
 		setSystem(true);
 	}
 
@@ -42,15 +44,9 @@ public class DelayedSnapshotJob extends Job {
 	public IStatus run(IProgressMonitor monitor) {
 		if (monitor.isCanceled())
 			return Status.CANCEL_STATUS;
-
-		try {
-			ResourcesPlugin.getWorkspace();
-		} catch (IllegalStateException e) {
-			// workspace is null, log it as warning only and return OK_STATUS
-			Policy.log(IStatus.WARNING, null, e);
+		if (!workspace.isOpen()) {
 			return Status.OK_STATUS;
 		}
-
 		try {
 			return saveManager.save(ISaveContext.SNAPSHOT, null, Policy.monitorFor(null));
 		} catch (CoreException e) {

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/SaveManager.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/SaveManager.java
@@ -17,6 +17,7 @@
  *     Sergey Prigogin (Google) - [437005] Out-of-date .snap file prevents Eclipse from running
  *     Lars Vogel <Lars.Vogel@vogella.com> - Bug 473427
  *     Mickael Istria (Red Hat Inc.) - Bug 488937
+ *     Christoph Läubrich - Issue #77 - SaveManager access the ResourcesPlugin.getWorkspace at init phase
  *******************************************************************************/
 package org.eclipse.core.internal.resources;
 
@@ -140,7 +141,7 @@ public class SaveManager implements IElementInfoFlattener, IManager, IStringPool
 	public SaveManager(Workspace workspace) {
 		this.workspace = workspace;
 		this.masterTable = new MasterTable();
-		this.snapshotJob = new DelayedSnapshotJob(this);
+		this.snapshotJob = new DelayedSnapshotJob(this, workspace);
 		snapshotRequested = false;
 		snapshotRequestor = null;
 		saveParticipants = Collections.synchronizedMap(new HashMap<>(10));


### PR DESCRIPTION
Fix https://github.com/eclipse-platform/eclipse.platform.resources/issues/77
Blocks: https://github.com/eclipse-platform/eclipse.platform.resources/pull/71