### PR TITLE
CharsetManager access the ResourcesPlugin.getWorkspace before init

### DIFF
--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/CharsetManager.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/CharsetManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2015 IBM Corporation and others.
+ * Copyright (c) 2004, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,7 @@
  *     James Blackburn (Broadcom Corp.) - ongoing development
  *     Tom Hochstein (Freescale) - Bug 409996 - 'Restore Defaults' does not work properly on Project Properties > Resource tab
  *     Lars Vogel <Lars.Vogel@vogella.com> - Bug 473427
+ *     Christoph Läubrich - Issue #80 - CharsetManager access the ResourcesPlugin.getWorkspace before init
  *******************************************************************************/
 package org.eclipse.core.internal.resources;
 
@@ -447,7 +448,7 @@ public class CharsetManager implements IManager {
 				flushPreferences(encodingSettings, true);
 				if (resource instanceof IProject) {
 					IProject project = (IProject) resource;
-					ValidateProjectEncoding.scheduleProjectValidation(project);
+					ValidateProjectEncoding.scheduleProjectValidation(workspace, project);
 				}
 			} catch (BackingStoreException e) {
 				IProject project = workspace.getRoot().getProject(resourcePath.segment(0));
@@ -507,6 +508,6 @@ public class CharsetManager implements IManager {
 		workspace.addResourceChangeListener(resourceChangeListener, IResourceChangeEvent.POST_CHANGE);
 		charsetListener = new CharsetDeltaJob(workspace);
 		charsetListener.startup();
-		ValidateProjectEncoding.scheduleWorkspaceValidation();
+		ValidateProjectEncoding.scheduleWorkspaceValidation(workspace);
 	}
 }

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/InternalWorkspaceJob.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/InternalWorkspaceJob.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2014 IBM Corporation and others.
+ * Copyright (c) 2003, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,11 +10,11 @@
  *
  * Contributors:
  *     IBM - Initial API and implementation
+ *     Christoph Läubrich - Issue #80 - CharsetManager access the ResourcesPlugin.getWorkspace before init
  *******************************************************************************/
 package org.eclipse.core.internal.resources;
 
 import org.eclipse.core.internal.utils.Policy;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.*;
 import org.eclipse.core.runtime.jobs.Job;
 
@@ -25,9 +25,9 @@ import org.eclipse.core.runtime.jobs.Job;
 public abstract class InternalWorkspaceJob extends Job {
 	private Workspace workspace;
 
-	public InternalWorkspaceJob(String name) {
+	public InternalWorkspaceJob(String name, Workspace workspace) {
 		super(name);
-		this.workspace = (Workspace) ResourcesPlugin.getWorkspace();
+		this.workspace = workspace;
 	}
 
 	@Override

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Project.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Project.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,7 @@
  *     Markus Schorn (Wind River) - [306575] Save snapshot location with project
  *     Broadcom Corporation - ongoing development
  *     Lars Vogel <Lars.Vogel@vogella.com> - Bug 473427
+ *     Christoph Läubrich - Issue #80 - CharsetManager access the ResourcesPlugin.getWorkspace before init
  *******************************************************************************/
 package org.eclipse.core.internal.resources;
 
@@ -1115,7 +1116,7 @@ public class Project extends Container implements IProject {
 			monitor.done();
 		}
 		if (!encodingWritten) {
-			ValidateProjectEncoding.scheduleProjectValidation(this);
+			ValidateProjectEncoding.scheduleProjectValidation((Workspace) getWorkspace(), this);
 		}
 	}
 

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/WorkspaceJob.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/WorkspaceJob.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2015 IBM Corporation and others.
+ * Copyright (c) 2003, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,10 +10,12 @@
  *
  * Contributors:
  *     IBM - Initial API and implementation
+ *     Christoph Läubrich - Issue #80 - CharsetManager access the ResourcesPlugin.getWorkspace before init
  *******************************************************************************/
 package org.eclipse.core.resources;
 
 import org.eclipse.core.internal.resources.InternalWorkspaceJob;
+import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.runtime.*;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
 
@@ -63,7 +65,7 @@ public abstract class WorkspaceJob extends InternalWorkspaceJob {
 	 * @param name the name of the job
 	 */
 	public WorkspaceJob(String name) {
-		super(name);
+		super(name, (Workspace) ResourcesPlugin.getWorkspace());
 	}
 
 	/**


### PR DESCRIPTION
Fix https://github.com/eclipse-platform/eclipse.platform.resources/issues/80
Blocks: https://github.com/eclipse-platform/eclipse.platform.resources/pull/71