### PR TITLE
RefreshManager access ResourcesPlugin.getWorkspace in the init phase

### DIFF
--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/refresh/RefreshJob.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/refresh/RefreshJob.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2004, 2015 IBM Corporation and others.
+ *  Copyright (c) 2004, 2022 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -12,11 +12,14 @@
  *     IBM - Initial API and implementation
  *     James Blackburn (Broadcom Corp.) - ongoing development
  *     Lars Vogel <Lars.Vogel@vogella.com> - Bug 473427, 483862
+ *     Christoph Läubrich - Issue #84 - RefreshManager access ResourcesPlugin.getWorkspace in the init phase
  *******************************************************************************/
 package org.eclipse.core.internal.refresh;
 
 import java.util.*;
 import org.eclipse.core.internal.localstore.PrefixPool;
+import org.eclipse.core.internal.resources.InternalWorkspaceJob;
+import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.internal.utils.Messages;
 import org.eclipse.core.internal.utils.Policy;
 import org.eclipse.core.resources.*;
@@ -29,7 +32,7 @@ import org.eclipse.core.runtime.*;
  *
  * @since 3.0
  */
-public class RefreshJob extends WorkspaceJob {
+public class RefreshJob extends InternalWorkspaceJob {
 
 	/**
 	 * Max refresh recursion deep
@@ -78,17 +81,17 @@ public class RefreshJob extends WorkspaceJob {
 	private final int updateDelay;
 	private final int maxRecursionDeep;
 
-	public RefreshJob() {
+	public RefreshJob(Workspace workspace) {
 		this(FAST_REFRESH_THRESHOLD, SLOW_REFRESH_THRESHOLD, BASE_REFRESH_DEPTH, DEPTH_INCREASE_STEP, UPDATE_DELAY,
-				MAX_RECURSION);
+				MAX_RECURSION, workspace);
 	}
 
 	/**
 	 * This method is protected for tests
 	 */
 	protected RefreshJob(int fastRefreshThreshold, int slowRefreshThreshold, int baseRefreshDepth,
-			int depthIncreaseStep, int updateDelay, int maxRecursionDeep) {
-		super(Messages.refresh_jobName);
+			int depthIncreaseStep, int updateDelay, int maxRecursionDeep, Workspace workspace) {
+		super(Messages.refresh_jobName, workspace);
 		this.fRequests = new ArrayList<>(1);
 		this.fastRefreshThreshold = fastRefreshThreshold;
 		this.slowRefreshThreshold = slowRefreshThreshold;

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/refresh/RefreshManager.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/refresh/RefreshManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2015 IBM Corporation and others.
+ * Copyright (c) 2004, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,12 +10,15 @@
  *
  * Contributors:
  *     IBM - Initial API and implementation
+ *     Christoph Läubrich - Issue #84 - RefreshManager access ResourcesPlugin.getWorkspace in the init phase
  *******************************************************************************/
 package org.eclipse.core.internal.refresh;
 
 import org.eclipse.core.internal.resources.IManager;
+import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.internal.utils.Messages;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.resources.refresh.IRefreshMonitor;
 import org.eclipse.core.resources.refresh.IRefreshResult;
 import org.eclipse.core.runtime.*;
@@ -36,9 +39,9 @@ public class RefreshManager implements IRefreshResult, IManager, Preferences.IPr
 	/**
 	 * The workspace.
 	 */
-	private IWorkspace workspace;
+	private Workspace workspace;
 
-	public RefreshManager(IWorkspace workspace) {
+	public RefreshManager(Workspace workspace) {
 		this.workspace = workspace;
 	}
 
@@ -115,7 +118,7 @@ public class RefreshManager implements IRefreshResult, IManager, Preferences.IPr
 		Preferences preferences = ResourcesPlugin.getPlugin().getPluginPreferences();
 		preferences.addPropertyChangeListener(this);
 
-		refreshJob = new RefreshJob();
+		refreshJob = new RefreshJob(workspace);
 		monitors = new MonitorManager(workspace, this);
 		boolean autoRefresh = preferences.getBoolean(ResourcesPlugin.PREF_AUTO_REFRESH);
 		if (autoRefresh)

--- a/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/refresh/RefreshJobTest.java
+++ b/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/refresh/RefreshJobTest.java
@@ -335,7 +335,7 @@ public class RefreshJobTest extends ResourceTest {
 		protected TestRefreshJob(int fastRefreshThreshold, int slowRefreshThreshold, int baseRefreshDepth,
 				int depthIncreaseStep, int updateDelay, int maxRecursionDeep) {
 			super(fastRefreshThreshold, slowRefreshThreshold, baseRefreshDepth,
-					depthIncreaseStep, updateDelay, maxRecursionDeep);
+					depthIncreaseStep, updateDelay, maxRecursionDeep, (Workspace) ResourcesPlugin.getWorkspace());
 		}
 
 		@Override


### PR DESCRIPTION
Fix https://github.com/eclipse-platform/eclipse.platform.resources/issues/84
Blocks https://github.com/eclipse-platform/eclipse.platform.resources/pull/71