### PR TITLE
fix testBuilderDeltaUsingRelaxedRuleBug343256 #19

### DIFF
--- a/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AbstractBuilderTest.java
+++ b/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AbstractBuilderTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.internal.builders;
 
 import java.util.Map;
+import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.ResourceTest;
@@ -72,6 +73,13 @@ public abstract class AbstractBuilderTest extends ResourceTest {
 	 * Sets the workspace autobuilding to the desired value.
 	 */
 	protected void setAutoBuilding(boolean value) throws CoreException {
+		changeAutoBuilding(value);
+		if (!value) {
+			((Workspace) getWorkspace()).getBuildManager().waitForAutoBuild();
+		}
+	}
+
+	private void changeAutoBuilding(boolean value) throws CoreException {
 		IWorkspace workspace = getWorkspace();
 		if (workspace.isAutoBuilding() == value) {
 			return;

--- a/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/RepeatedTestSuite.java
+++ b/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/RepeatedTestSuite.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources;
 
 import junit.framework.*;
+import org.eclipse.core.tests.internal.builders.RelaxedSchedRuleBuilderTest;
 
 /** can be manual started for testing random fails **/
 public class RepeatedTestSuite extends TestCase {
@@ -21,7 +22,7 @@ public class RepeatedTestSuite extends TestCase {
         TestSuite suite = new TestSuite(RepeatedTestSuite.class.getName());
 
 		for (int i = 0; i < 1000; i++) {
-			suite.addTestSuite(MarkerTest.class); // the test to repeat
+			suite.addTestSuite(RelaxedSchedRuleBuilderTest.class); // the test to repeat
         }
         return suite;
     }

--- a/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
+++ b/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
@@ -19,9 +19,10 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.attribute.FileTime;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 import org.eclipse.core.filesystem.*;
 import org.eclipse.core.internal.resources.*;
 import org.eclipse.core.internal.utils.FileUtil;
@@ -71,6 +72,18 @@ public abstract class ResourceTest extends CoreTest {
 	protected static final String SET_OTHER = "org.eclipse.core.tests.resources.otherSet";
 	//constants for nature sets
 	protected static final String SET_STATE = "org.eclipse.core.tests.resources.stateSet";
+	/**
+	 * Number of received log messages with severity error while running a single
+	 * test method.
+	 */
+	private final Queue<IStatus> loggedErrors = new ConcurrentLinkedQueue<>();
+
+	/** Listener to count error messages while testing. */
+	private final ILogListener errorLogListener = (IStatus status, String plugin) -> {
+		if (status.matches(IStatus.ERROR)) {
+			loggedErrors.add(status);
+		}
+	};
 
 	/**
 	 * Set of FileStore instances that must be deleted when the
@@ -986,16 +999,33 @@ public abstract class ResourceTest extends CoreTest {
 		TestUtil.log(IStatus.INFO, getName(), "setUp");
 		FreezeMonitor.expectCompletionInAMinute();
 		assertNotNull("Workspace was not setup", getWorkspace());
+		loggedErrors.clear();
+		Platform.addLogListener(errorLogListener);
 	}
 
 	@Override
 	protected void tearDown() throws Exception {
+		Platform.removeLogListener(errorLogListener);
 		TestUtil.log(IStatus.INFO, getName(), "tearDown");
 		// Ensure everything is in a clean state for next one.
 		// Session tests should overwrite it.
 		cleanup();
 		super.tearDown();
 		FreezeMonitor.done();
+	}
+
+	protected void assertNoErrorsLogged() {
+		List<IStatus> errorlist = new ArrayList<>();
+		loggedErrors.removeIf(errorlist::add);
+		errorlist.forEach(status -> {
+			if (status.getException() != null) {
+				throw new AssertionError("Test logged exception", status.getException());
+			}
+		});
+		assertTrue(
+				"Test logged errors: "
+						+ errorlist.stream().map(IStatus::toString).collect(Collectors.joining(", ")),
+				errorlist.isEmpty());
 	}
 
 	/**


### PR DESCRIPTION
in RelaxedSchedRuleBuilderTest.
Basically reversed the order in which the jobs are joined because j1 can
not finish before j2.