### PR TITLE
Fixes bug reference for error message "Trees in ambiguous order"

### DIFF
--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/SaveManager.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/SaveManager.java
@@ -1563,7 +1563,7 @@ public class SaveManager implements IElementInfoFlattener, IManager, IStringPool
 			String s = List.of(trees).stream().distinct().sorted(Comparator.comparing(ElementTree::getTreeStamp))
 					.map(t -> (t.isImmutable() ? "" : "mutable! ") + parentChain(t)) //$NON-NLS-1$ //$NON-NLS-2$
 					.collect(Collectors.joining(", ")); //$NON-NLS-1$
-			Exception e = new NullPointerException("Given trees not in unambiguous order (Bug 35286): " + s); //$NON-NLS-1$
+			Exception e = new NullPointerException("Given trees not in unambiguous order (Bug 352867): " + s); //$NON-NLS-1$
 			IStatus status = new Status(IStatus.WARNING, ResourcesPlugin.PI_RESOURCES, IResourceStatus.INTERNAL_ERROR,
 					e.getMessage(), e);
 			Policy.log(status);

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/watson/ElementTreeWriter.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/watson/ElementTreeWriter.java
@@ -88,7 +88,7 @@ public class ElementTreeWriter {
 	protected ElementTree[] writeSortedTrees(ElementTree[] trees, DataOutput output) throws IOException {
 		ElementTree[] sorted = SaveManager.sortTrees(trees);
 		if (sorted == null) {
-			throw new IOException("Trees in ambiguous order (Bug 35286)"); //$NON-NLS-1$
+			throw new IOException("Trees in ambiguous order (Bug 352867)"); //$NON-NLS-1$
 		}
 
 		// compute indexes from sorted elements:

--- a/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/watson/TreeFlatteningTest.java
+++ b/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/watson/TreeFlatteningTest.java
@@ -94,7 +94,7 @@ public class TreeFlatteningTest extends ElementTreeSerializationTest {
 		ElementTree[] sorted = SaveManager.sortTrees(trees);
 		assertNull(sorted); // => not sortable
 		// logs java.lang.NullPointerException: Given trees not in unambiguous order
-		// (Bug 35286): 16->17->18, 17->18, 18, mutable! 19->18
+		// (Bug 352867): 16->17->18, 17->18, 18, mutable! 19->18
 	}
 
 	@Test


### PR DESCRIPTION
Currenty bug reference is wrong, this commit updates it to the correct
bug number.

For #112