### PR TITLE
Error log on shutdown without stack: "Workspace was not properly initialized or has already shutdown" (Fixes #114)

### DIFF
--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Workspace.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Workspace.java
@@ -1811,7 +1811,7 @@ public class Workspace extends PlatformObject implements IWorkspace, ICoreConsta
 	public WorkManager getWorkManager() throws CoreException {
 		if (_workManager == null) {
 			String message = Messages.resources_shutdown;
-			throw new ResourceException(new ResourceStatus(IResourceStatus.INTERNAL_ERROR, null, message));
+			throw new ResourceException(IResourceStatus.INTERNAL_ERROR, null, message, null);
 		}
 		return _workManager;
 	}


### PR DESCRIPTION
Add stack to the core exception.

Fixes https://github.com/eclipse-platform/eclipse.platform.resources/issues/114