### PR TITLE
fix Exception handling to show broken workspace file location

### DIFF
--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/SaveManager.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/SaveManager.java
@@ -1043,7 +1043,7 @@ public class SaveManager implements IElementInfoFlattener, IManager, IStringPool
 		}
 		try (DataInputStream input = new DataInputStream(new SafeFileInputStream(treeLocation.toOSString(), tempLocation.toOSString(), TREE_BUFFER_SIZE))) {
 			WorkspaceTreeReader.getReader(workspace, input.readInt()).readTree(input, monitor);
-		} catch (IOException e) {
+		} catch (Exception e) { // "Unknown format" is passed as ResourceException
 			String msg = NLS.bind(Messages.resources_readMeta, treeLocation.toOSString());
 			throw new ResourceException(IResourceStatus.FAILED_READ_METADATA, treeLocation, msg, e);
 		}


### PR DESCRIPTION
When during loading of the workspace an "Unknown format" Exception
happens the error message did not include any information which file was
broken.
The Exception is passed as ResourceException which is not an
IOException.
Now we add the file location for any Exception that happens while
loading.