### PR TITLE
Apply Remove overridden assignment JDT clean in core.resources

### DIFF
--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/events/BuildCommand.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/events/BuildCommand.java
@@ -103,8 +103,7 @@ public class BuildCommand extends ModelObject implements ICommand {
 
 	@Override
 	public Object clone() {
-		BuildCommand result = null;
-		result = (BuildCommand) super.clone();
+		BuildCommand result = (BuildCommand) super.clone();
 		if (result == null)
 			return null;
 		result.setArguments(getArguments());

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/PlatformURLResourceConnection.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/PlatformURLResourceConnection.java
@@ -62,8 +62,6 @@ public class PlatformURLResourceConnection extends PlatformURLConnection {
 		}
 
 		IResource resource = null;
-		IPath result = null;
-
 		if (count == 2) {
 			resource = project;
 		} else {
@@ -71,7 +69,7 @@ public class PlatformURLResourceConnection extends PlatformURLConnection {
 			resource = project.getFile(spec);
 		}
 
-		result = resource.getLocation();
+		IPath result = resource.getLocation();
 
 		if (result == null) {
 			URI uri = resource.getLocationURI();

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Workspace.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Workspace.java
@@ -1979,8 +1979,7 @@ public class Workspace extends PlatformObject implements IWorkspace, ICoreConsta
 
 	@Override
 	public IProjectDescription loadProjectDescription(InputStream stream) throws CoreException {
-		IProjectDescription result = null;
-		result = new ProjectDescriptionReader(this).read(new InputSource(stream));
+		IProjectDescription result = new ProjectDescriptionReader(this).read(new InputSource(stream));
 		if (result == null) {
 			String message = NLS.bind(Messages.resources_errorReadProject, stream.toString());
 			IStatus status = new Status(IStatus.ERROR, ResourcesPlugin.PI_RESOURCES, IResourceStatus.FAILED_READ_METADATA, message, null);

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/utils/FileUtil.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/utils/FileUtil.java
@@ -306,9 +306,8 @@ public class FileUtil {
 			}
 		}
 		Preferences rootNode = Platform.getPreferencesService().getRootNode();
-		String value = null;
-		// if the file does not exist or has no content yet, try with project preferences
-		value = getLineSeparatorFromPreferences(rootNode.node(ProjectScope.SCOPE).node(file.getProject().getName()));
+		// if the file does not exist or has no content yet, try with project preference
+		String value = getLineSeparatorFromPreferences(rootNode.node(ProjectScope.SCOPE).node(file.getProject().getName()));
 		if (value != null)
 			return value;
 		// try with instance preferences

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/watson/ElementTreeWriter.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/watson/ElementTreeWriter.java
@@ -128,9 +128,7 @@ public class ElementTreeWriter {
 		 */
 		DeltaDataTree completeTree = newerTree.getDataTree();
 		DeltaDataTree derivedTree = olderTree.getDataTree();
-		DeltaDataTree deltaToWrite = null;
-
-		deltaToWrite = completeTree.forwardDeltaWith(derivedTree, comparator);
+		DeltaDataTree deltaToWrite = completeTree.forwardDeltaWith(derivedTree, comparator);
 
 		Assert.isTrue(deltaToWrite.isImmutable());
 		dataTreeWriter.writeTree(deltaToWrite, path, depth, output);


### PR DESCRIPTION
Dogfooding the improve JDT cleanup from Bug 572440 to ensure the JDT
cleanup is stable and functional. Push in small chunks to make review
easier.