### PR TITLE
RefreshJob should be cancelled earlier on shutdown (Fixes #133)

### DIFF
--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/refresh/RefreshJob.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/refresh/RefreshJob.java
@@ -83,6 +83,7 @@ public class RefreshJob extends InternalWorkspaceJob {
 	private final int updateDelay;
 	private final int maxRecursionDeep;
 	private final Workspace workspace;
+	private volatile boolean disabled;
 
 	public RefreshJob(Workspace workspace) {
 		this(FAST_REFRESH_THRESHOLD, SLOW_REFRESH_THRESHOLD, BASE_REFRESH_DEPTH, DEPTH_INCREASE_STEP, UPDATE_DELAY,
@@ -195,8 +196,9 @@ public class RefreshJob extends InternalWorkspaceJob {
 	 * @see org.eclipse.core.resources.refresh.IRefreshResult#refresh
 	 */
 	public void refresh(IResource resource) {
-		if (resource == null)
+		if (resource == null || disabled) {
 			return;
+		}
 		addRequest(resource);
 		schedule(updateDelay);
 	}
@@ -277,16 +279,20 @@ public class RefreshJob extends InternalWorkspaceJob {
 	 * Starts the refresh job
 	 */
 	public void start() {
-		if (Policy.DEBUG_AUTO_REFRESH)
+		if (Policy.DEBUG_AUTO_REFRESH) {
 			Policy.debug(RefreshManager.DEBUG_PREFIX + " enabling auto-refresh"); //$NON-NLS-1$
+		}
+		disabled = false;
 	}
 
 	/**
 	 * Stops the refresh job
 	 */
 	public void stop() {
-		if (Policy.DEBUG_AUTO_REFRESH)
+		if (Policy.DEBUG_AUTO_REFRESH) {
 			Policy.debug(RefreshManager.DEBUG_PREFIX + " disabling auto-refresh"); //$NON-NLS-1$
+		}
+		disabled = true;
 		cancel();
 	}
 }

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Workspace.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Workspace.java
@@ -625,6 +625,8 @@ public class Workspace extends PlatformObject implements IWorkspace, ICoreConsta
 		try {
 			try {
 				stringPoolJob.cancel();
+				// stop accepting refresh tasks & doing refresh
+				refreshManager.shutdown(null);
 				//shutdown save manager now so a last snapshot can be taken before we close
 				//note: you can't call #save() from within a nested operation
 				saveManager.shutdown(null);


### PR DESCRIPTION
As of today, RefreshJob was cancelled too late during workspace
shutdown, so it was allowed to be run in parallel to workspace save, and
it was also possible to schedule it again even after
RefreshManager.shutdown() was called.

This is not OK, and could result in various errors.

With this change we cancel and *disable* RefreshJob from scheduling if
stop() was called, and shutdown RefreshManager *before* saving workspace
state in Workspace.close(), so it can't run in parallel or after save.

See https://github.com/eclipse-platform/eclipse.platform.resources/issues/133