### PR TITLE
Fix tests not properly using PREF_AUTO_REFRESH

### DIFF
--- a/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/refresh/RefreshProviderTest.java
+++ b/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/refresh/RefreshProviderTest.java
@@ -18,8 +18,11 @@ import java.util.Map;
 import junit.framework.AssertionFailedError;
 import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.resources.*;
-import org.eclipse.core.runtime.*;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.core.tests.resources.ResourceTest;
 import org.eclipse.core.tests.resources.TestUtil;
 
@@ -28,14 +31,16 @@ import org.eclipse.core.tests.resources.TestUtil;
  */
 public class RefreshProviderTest extends ResourceTest {
 
+	private boolean originalRefreshSetting;
+
 	@Override
 	protected void setUp() throws Exception {
 		super.setUp();
 		TestRefreshProvider.reset();
 		//turn on autorefresh
-		Preferences preferences = ResourcesPlugin.getPlugin().getPluginPreferences();
-		preferences.setValue(ResourcesPlugin.PREF_AUTO_REFRESH, true);
-
+		IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES);
+		originalRefreshSetting = prefs.getBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, false);
+		prefs.putBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, true);
 	}
 
 	@Override
@@ -43,8 +48,8 @@ public class RefreshProviderTest extends ResourceTest {
 		super.tearDown();
 		//turn off autorefresh
 		TestRefreshProvider.reset();
-		Preferences preferences = ResourcesPlugin.getPlugin().getPluginPreferences();
-		preferences.setValue(ResourcesPlugin.PREF_AUTO_REFRESH, false);
+		IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES);
+		prefs.putBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, originalRefreshSetting);
 	}
 
 	/**

--- a/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_303517.java
+++ b/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_303517.java
@@ -20,6 +20,7 @@ import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.core.tests.resources.ResourceTest;
 
@@ -30,6 +31,7 @@ import org.eclipse.core.tests.resources.ResourceTest;
 public class Bug_303517 extends ResourceTest {
 
 	String[] resources = new String[] {"/", "/Bug303517/", "/Bug303517/Folder/", "/Bug303517/Folder/Resource",};
+	private boolean originalRefreshSetting;
 
 	@Override
 	public String[] defineHierarchy() {
@@ -39,13 +41,18 @@ public class Bug_303517 extends ResourceTest {
 	@Override
 	protected void setUp() throws Exception {
 		super.setUp();
-		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).putBoolean(ResourcesPlugin.PREF_LIGHTWEIGHT_AUTO_REFRESH, true);
+		IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES);
+		originalRefreshSetting = prefs.getBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, false);
+		prefs.putBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, true);
+		prefs.putBoolean(ResourcesPlugin.PREF_LIGHTWEIGHT_AUTO_REFRESH, true);
 	}
 
 	@Override
 	protected void tearDown() throws Exception {
+		IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES);
+		prefs.putBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, originalRefreshSetting);
+		prefs.putBoolean(ResourcesPlugin.PREF_LIGHTWEIGHT_AUTO_REFRESH, false);
 		super.tearDown();
-		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).putBoolean(ResourcesPlugin.PREF_LIGHTWEIGHT_AUTO_REFRESH, false);
 	}
 
 	/**


### PR DESCRIPTION
Bug_303517 depends on PREF_AUTO_REFRESH *enabled*.
RefreshProviderTest unconditionally disables PREF_AUTO_REFRESH.

See https://github.com/eclipse-platform/eclipse.platform.resources/issues/133