### PR TITLE
Don't use "file.encoding", use Platform.getSystemCharset() instead

### DIFF
--- a/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
@@ -27,7 +27,7 @@ Export-Package: org.eclipse.core.internal.dtree;x-internal:=true,
 Require-Bundle: org.eclipse.ant.core;bundle-version="[3.1.0,4.0.0)";resolution:=optional,
  org.eclipse.core.expressions;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.core.filesystem;bundle-version="[1.3.0,2.0.0)",
- org.eclipse.core.runtime;bundle-version="[3.25.0,4.0.0)"
+ org.eclipse.core.runtime;bundle-version="[3.26.0,4.0.0)"
 Bundle-ActivationPolicy: lazy
 Service-Component: OSGI-INF/ResourceChangeListenerRegistrar.xml,
  OSGI-INF/org.eclipse.core.internal.resources.CheckMissingNaturesListener.xml


### PR DESCRIPTION
With https://openjdk.java.net/jeps/400 implemented in Java 18,
"file.encoding" system property became meaningless and can't be used
anymore to determine system native encoding.

Instead, use new Platform.getNativeEncoding() API that tries to provide
a suitable replacement compatible with Java 18+ and previous Java
versions.

Note: this PR requires https://github.com/eclipse-platform/eclipse.platform.runtime/pull/63 to be merged first.

See https://github.com/eclipse-platform/eclipse.platform.resources/issues/154