### PR TITLE
Improve IFile.getLineSeparator() API

### DIFF
--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/FileSystemResourceManager.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/FileSystemResourceManager.java
@@ -637,7 +637,7 @@ public class FileSystemResourceManager implements ICoreConstants, IManager, Pref
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		IFile descriptionFile = target.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
 		try {
-			new ModelObjectWriter().write(description, out, FileUtil.getLineSeparator(descriptionFile));
+			new ModelObjectWriter().write(description, out, descriptionFile.getLineSeparator(true));
 		} catch (IOException e) {
 			String msg = NLS.bind(Messages.resources_writeMeta, target.getFullPath());
 			throw new ResourceException(IResourceStatus.FAILED_WRITE_METADATA, target.getFullPath(), msg, e);
@@ -1243,7 +1243,7 @@ public class FileSystemResourceManager implements ICoreConstants, IManager, Pref
 			OutputStream out = fileStore.openOutputStream(EFS.NONE, null)
 		) {
 			IFile file = target.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
-			new ModelObjectWriter().write(desc, out, FileUtil.getLineSeparator(file));
+			new ModelObjectWriter().write(desc, out, file.getLineSeparator(true));
 		} catch (IOException e) {
 			String msg = NLS.bind(Messages.resources_writeMeta, target.getFullPath());
 			throw new ResourceException(IResourceStatus.FAILED_WRITE_METADATA, target.getFullPath(), msg, e);

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/File.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/File.java
@@ -438,4 +438,35 @@ public class File extends Resource implements IFile {
 		updateFlags |= keepHistory ? IResource.KEEP_HISTORY : IResource.NONE;
 		setContents(source.getContents(), updateFlags, monitor);
 	}
+
+	@Override
+	public String getLineSeparator(boolean checkParent) throws CoreException {
+		if (exists()) {
+			try (
+					// for performance reasons the buffer size should
+					// reflect the average length of the first Line:
+					InputStream input = new BufferedInputStream(getContents(), 128);) {
+				int c = input.read();
+				while (c != -1 && c != '\r' && c != '\n')
+					c = input.read();
+				if (c == '\n')
+					return "\n"; //$NON-NLS-1$
+				if (c == '\r') {
+					if (input.read() == '\n')
+						return "\r\n"; //$NON-NLS-1$
+					return "\r"; //$NON-NLS-1$
+				}
+			} catch (CoreException core) {
+				if (!checkParent) {
+					throw core;
+				}
+			} catch (IOException io) {
+				if (!checkParent) {
+					throw new CoreException(Status.error(io.getMessage(), io));
+				}
+			}
+		}
+		return checkParent ? getProject().getDefaultLineSeparator() : null;
+	}
+
 }

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Project.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Project.java
@@ -32,7 +32,10 @@ import org.eclipse.core.runtime.*;
 import org.eclipse.core.runtime.content.IContentTypeMatcher;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.preferences.DefaultScope;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.osgi.util.NLS;
+import org.osgi.service.prefs.Preferences;
 
 public class Project extends Container implements IProject {
 	/**
@@ -1419,5 +1422,35 @@ public class Project extends Container implements IProject {
 		} finally {
 			ProjectDescription.isWriting = false;
 		}
+	}
+
+	@Override
+	public String getDefaultLineSeparator() {
+		Preferences rootNode = Platform.getPreferencesService().getRootNode();
+		// if the file does not exist or has no content yet, try with project preference
+		String value = getLineSeparatorFromPreferences(rootNode.node(ProjectScope.SCOPE).node(getProject().getName()));
+		if (value != null)
+			return value;
+		// try with instance preferences
+		value = getLineSeparatorFromPreferences(rootNode.node(InstanceScope.SCOPE));
+		if (value != null)
+			return value;
+		// try with default preferences
+		value = getLineSeparatorFromPreferences(rootNode.node(DefaultScope.SCOPE));
+		if (value != null)
+			return value;
+		// if there is no preference set, fall back to OS default value
+		return System.lineSeparator();
+	}
+
+	private static String getLineSeparatorFromPreferences(Preferences node) {
+		try {
+			// be careful looking up for our node so not to create any nodes as side effect
+			if (node.nodeExists(Platform.PI_RUNTIME))
+				return node.node(Platform.PI_RUNTIME).get(Platform.PREF_LINE_SEPARATOR, null);
+		} catch (org.osgi.service.prefs.BackingStoreException e) {
+			// ignore
+		}
+		return null;
 	}
 }

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/ProjectPreferences.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/ProjectPreferences.java
@@ -23,7 +23,8 @@ import java.text.MessageFormat;
 import java.util.*;
 import java.util.Map.Entry;
 import org.eclipse.core.internal.preferences.*;
-import org.eclipse.core.internal.utils.*;
+import org.eclipse.core.internal.utils.Messages;
+import org.eclipse.core.internal.utils.Policy;
 import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.*;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
@@ -681,7 +682,7 @@ public class ProjectPreferences extends EclipsePreferences {
 					// print the table to a string and remove the timestamp that Properties#store always adds
 					String s = removeTimestampFromTable(table);
 					String systemLineSeparator = System.lineSeparator();
-					String fileLineSeparator = FileUtil.getLineSeparator(fileInWorkspace);
+					String fileLineSeparator = fileInWorkspace.getLineSeparator(true);
 					if (!systemLineSeparator.equals(fileLineSeparator))
 						s = s.replaceAll(systemLineSeparator, fileLineSeparator);
 					InputStream input = new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8));

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/utils/FileUtil.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/utils/FileUtil.java
@@ -22,14 +22,11 @@ import org.eclipse.core.filesystem.*;
 import org.eclipse.core.filesystem.URIUtil;
 import org.eclipse.core.internal.resources.ResourceException;
 import org.eclipse.core.internal.resources.Workspace;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IResourceStatus;
+import org.eclipse.core.resources.ResourceAttributes;
 import org.eclipse.core.runtime.*;
-import org.eclipse.core.runtime.preferences.DefaultScope;
-import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.osgi.service.environment.Constants;
 import org.eclipse.osgi.util.NLS;
-import org.osgi.service.prefs.BackingStoreException;
-import org.osgi.service.prefs.Preferences;
 
 /**
  * Static utility methods for manipulating Files and URIs.
@@ -258,64 +255,6 @@ public class FileUtil {
 		attributes.set(EFS.ATTRIBUTE_OTHER_WRITE, fileInfo.getAttribute(EFS.ATTRIBUTE_OTHER_WRITE));
 		attributes.set(EFS.ATTRIBUTE_OTHER_EXECUTE, fileInfo.getAttribute(EFS.ATTRIBUTE_OTHER_EXECUTE));
 		return attributes;
-	}
-
-	private static String getLineSeparatorFromPreferences(Preferences node) {
-		try {
-			// be careful looking up for our node so not to create any nodes as side effect
-			if (node.nodeExists(Platform.PI_RUNTIME))
-				return node.node(Platform.PI_RUNTIME).get(Platform.PREF_LINE_SEPARATOR, null);
-		} catch (BackingStoreException e) {
-			// ignore
-		}
-		return null;
-	}
-
-	/**
-	 * @see org.eclipse.core.resources.ResourcesPlugin#getLineSeparator(IResource)
-	 */
-	public static String getLineSeparator(IResource resource) {
-		if (resource == null) {
-			// outside workspace use system setting
-			return System.lineSeparator();
-		}
-		if (resource instanceof IFile && resource.exists()) {
-			IFile file = (IFile) resource;
-			try (
-					// for performance reasons the buffer size should
-					// reflect the average length of the first Line:
-					InputStream input = new BufferedInputStream(file.getContents(), 128);
-			) {
-				int c = input.read();
-				while (c != -1 && c != '\r' && c != '\n')
-					c = input.read();
-				if (c == '\n')
-					return "\n"; //$NON-NLS-1$
-				if (c == '\r') {
-					if (input.read() == '\n')
-						return "\r\n"; //$NON-NLS-1$
-					return "\r"; //$NON-NLS-1$
-				}
-			} catch (CoreException | IOException e) {
-				// ignore
-			}
-		}
-		Preferences rootNode = Platform.getPreferencesService().getRootNode();
-		// if the file does not exist or has no content yet, try with project preference
-		String value = getLineSeparatorFromPreferences(
-				rootNode.node(ProjectScope.SCOPE).node(resource.getProject().getName()));
-		if (value != null)
-			return value;
-		// try with instance preferences
-		value = getLineSeparatorFromPreferences(rootNode.node(InstanceScope.SCOPE));
-		if (value != null)
-			return value;
-		// try with default preferences
-		value = getLineSeparatorFromPreferences(rootNode.node(DefaultScope.SCOPE));
-		if (value != null)
-			return value;
-		// if there is no preference set, fall back to OS default value
-		return System.lineSeparator();
 	}
 
 	/**

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/IFile.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/IFile.java
@@ -1162,4 +1162,35 @@ public interface IFile extends IResource, IEncodedStorage, IAdaptable {
 	 * @since 2.0
 	 */
 	void setContents(IFileState source, int updateFlags, IProgressMonitor monitor) throws CoreException;
+
+	/**
+	 * Returns line separator appropriate for the given file.
+	 * <p>
+	 * If checkParent is <code>false</code>, this method will return the line
+	 * separator by reading the file, or <code>null</code> otherwise.
+	 * </p>
+	 * <p>
+	 * If checkParent is <code>true</code>, this method uses the following algorithm
+	 * to determine the line separator to be returned:
+	 * </p>
+	 * <ol>
+	 * <li>the line separator currently used in that file (same as output with
+	 * checkImplicit=false), or</li>
+	 * <li>delegates to {@link IProject#getDefaultLineSeparator()}</li>
+	 * </ol>
+	 *
+	 * @param checkParent whether to look up in parent containers settings to
+	 *                    retrieve a value
+	 * @return line separator for the current file
+	 * @exception CoreException if this method fails. Reasons include:
+	 *                          <ul>
+	 *                          <li>This resource could not be read.</li>
+	 *                          <li>This resource is not local.</li>
+	 *                          <li>The corresponding location in the local file
+	 *                          system is occupied by a directory.</li>
+	 *                          </ul>
+	 * @see IProject#getDefaultLineSeparator()
+	 * @since 3.18
+	 */
+	public String getLineSeparator(boolean checkParent) throws CoreException;
 }

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/IProject.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/IProject.java
@@ -1054,4 +1054,23 @@ public interface IProject extends IContainer, IAdaptable {
 	 * @since 2.0
 	 */
 	void setDescription(IProjectDescription description, int updateFlags, IProgressMonitor monitor) throws CoreException;
+
+	/**
+	 * Returns line separator appropriate for new files in the given project.
+	 * <p>
+	 * This method uses the following algorithm to determine the line separator to
+	 * be returned:
+	 * </p>
+	 * <ol>
+	 * <li>the line separator defined in project preferences, or</li>
+	 * <li>the line separator defined in workspace preferences, or</li>
+	 * <li>the line separator defined in default preferences, or</li>
+	 * <li>Operating system default line separator</li>
+	 * </ol>
+	 *
+	 * @return line separator for the current file
+	 * @exception CoreException if this method fails.
+	 * @since 3.18
+	 */
+	String getDefaultLineSeparator() throws CoreException;
 }

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/ResourcesPlugin.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/ResourcesPlugin.java
@@ -370,25 +370,6 @@ public final class ResourcesPlugin extends Plugin {
 	private WorkspaceInitCustomizer workspaceInitCustomizer;
 
 	/**
-	 * Returns line separator appropriate for the given resource. The returned value
-	 * will be the first available value from the list below:
-	 * <ol>
-	 * <li>Line separator currently used in that file.
-	 * <li>Line separator defined in project preferences.
-	 * <li>Line separator defined in workspace preferences.
-	 * <li>Line separator defined in default preferences.
-	 * <li>Operating system default line separator (especially for null resource).
-	 * </ol>
-	 *
-	 * @param resource the resource for which line separator should be returned
-	 * @return line separator for the given resource
-	 * @since 3.18
-	 */
-	public static String getLineSeparator(IResource resource) {
-		return FileUtil.getLineSeparator(resource);
-	}
-
-	/**
 	 * Returns the encoding to use when reading text files in the workspace. This is
 	 * the value of the <code>PREF_ENCODING</code> preference, or the file system
 	 * encoding (<code>System.getProperty("file.encoding")</code>) if the preference


### PR DESCRIPTION
Previous proposal used wrong OO and discoverability patterns and are
inconsistent with other similar methods (IFile.getEncoding(), IFile.getCharset()...),
so better align with those.