### PR TITLE
Add default implementation to IFile.getLineSeparator

### DIFF
--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/IFile.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/IFile.java
@@ -1192,5 +1192,7 @@ public interface IFile extends IResource, IEncodedStorage, IAdaptable {
 	 * @see IProject#getDefaultLineSeparator()
 	 * @since 3.18
 	 */
-	public String getLineSeparator(boolean checkParent) throws CoreException;
+	public default String getLineSeparator(boolean checkParent) throws CoreException {
+		return getProject().getDefaultLineSeparator();
+	}
 }


### PR DESCRIPTION
This class is implemented in multiple tests and other utilities, so
adding a default implementation for the new method in order to avoid
breakage and to not require changes in those "exotic" implementations.