### PR TITLE
Remove unused Require-Bundle entries

### DIFF
--- a/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
@@ -28,14 +28,11 @@ Export-Package: org.eclipse.core.tests.filesystem,
  org.eclipse.core.tests.resources.regression,
  org.eclipse.core.tests.resources.session,
  org.eclipse.core.tests.resources.usecase
-Require-Bundle: org.eclipse.osgi.services,
- org.eclipse.core.resources,
+Require-Bundle: org.eclipse.core.resources,
  org.eclipse.core.tests.harness,
  org.junit,
- org.eclipse.test.performance,
  org.eclipse.core.filesystem,
  org.eclipse.core.runtime,
- org.eclipse.core.expressions,
  org.eclipse.pde.junit.runtime;bundle-version="3.5.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11


### PR DESCRIPTION
The main intention was to remove require bundle of
org.eclipse.osgi.services but other unused are removed too.