### PR TITLE
Add preference to change severity for missing project specific encoding

### DIFF
--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/PreferenceInitializer.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/PreferenceInitializer.java
@@ -11,6 +11,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     James Blackburn (Broadcom Corp.) - ongoing development
+ *     Ingo Mohr - Issue #166 - Add Preference to Turn Off Warning-Check for Project Specific Encoding
  *******************************************************************************/
 package org.eclipse.core.internal.resources;
 
@@ -50,6 +51,13 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 	 * @since 3.12
 	 */
 	public static final int PREF_MISSING_NATURE_MARKER_SEVERITY_DEFAULT = IMarker.SEVERITY_WARNING;
+	/**
+	 * Default setting for
+	 * {@value ResourcesPlugin#PREF_MISSING_ENCODING_MARKER_SEVERITY}.
+	 *
+	 * @since 3.18
+	 */
+	public static final int PREF_MISSING_ENCODING_MARKER_SEVERITY_DEFAULT = IMarker.SEVERITY_WARNING;
 
 	/**
 	 * @since 3.13
@@ -76,6 +84,8 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 		node.putInt(ResourcesPlugin.PREF_MAX_BUILD_ITERATIONS, PREF_MAX_BUILD_ITERATIONS_DEFAULT);
 		node.putBoolean(ResourcesPlugin.PREF_DEFAULT_BUILD_ORDER, PREF_DEFAULT_BUILD_ORDER_DEFAULT);
 		node.putInt(ResourcesPlugin.PREF_MISSING_NATURE_MARKER_SEVERITY, PREF_MISSING_NATURE_MARKER_SEVERITY_DEFAULT);
+		node.putInt(ResourcesPlugin.PREF_MISSING_ENCODING_MARKER_SEVERITY,
+				PREF_MISSING_ENCODING_MARKER_SEVERITY_DEFAULT);
 
 
 		// history store defaults

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/ResourcesPlugin.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/ResourcesPlugin.java
@@ -17,6 +17,7 @@
  *     Lars Vogel <Lars.Vogel@vogella.com> - Bug 473427
  *     Christoph Läubrich 	- Issue #52 - Make ResourcesPlugin more dynamic and better handling early start-up
  *     						- Issue #68 - Use DS for CheckMissingNaturesListener
+ *     Ingo Mohr - Issue #166 - Add Preference to Turn Off Warning-Check for Project Specific Encoding
  *******************************************************************************/
 package org.eclipse.core.resources;
 
@@ -354,6 +355,18 @@ public final class ResourcesPlugin extends Plugin {
 	 * @since 3.13
 	 */
 	public static final String PREF_MISSING_NATURE_MARKER_SEVERITY = "missingNatureMarkerSeverity"; //$NON-NLS-1$
+
+	/**
+	 * Name of a preference for configuring the marker severity in case project does
+	 * not specify its encoding.
+	 * <p>
+	 * Supported severities are those from {@link IMarker} and also <code>-1</code>
+	 * for "ignore".
+	 * </p>
+	 *
+	 * @since 3.18
+	 */
+	public static final String PREF_MISSING_ENCODING_MARKER_SEVERITY = "missingEncodingMarkerSeverity"; //$NON-NLS-1$
 
 	/**
 	 * Name of the preference to set max number of concurrent jobs running the workspace build.

--- a/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/AllTests.java
+++ b/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/AllTests.java
@@ -10,6 +10,7 @@
  *
  *  Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Ingo Mohr - Issue #166 - Add Preference to Turn Off Warning-Check for Project Specific Encoding
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
@@ -24,7 +25,8 @@ import org.junit.runners.Suite;
 		IResourceChangeListenerTest.class, IResourceDeltaTest.class, IResourceTest.class, ISynchronizerTest.class,
 		IWorkspaceRootTest.class, IWorkspaceTest.class, LinkedResourceTest.class,
 		LinkedResourceWithPathVariableTest.class, LinkedResourceSyncMoveAndCopyTest.class, MarkerSetTest.class,
-		MarkerTest.class, NatureTest.class, NonLocalLinkedResourceTest.class, ProjectOrderTest.class,
+		MarkerTest.class, NatureTest.class, NonLocalLinkedResourceTest.class, ProjectEncodingTest.class,
+		ProjectOrderTest.class,
 		ProjectScopeTest.class, ProjectSnapshotTest.class, ResourceAttributeTest.class, ResourceURLTest.class,
 		TeamPrivateMemberTest.class, WorkspaceTest.class })
 public class AllTests {

--- a/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectEncodingTest.java
+++ b/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectEncodingTest.java
@@ -1,0 +1,236 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Ingo Mohr - Issue #166 - Add Preference to Turn Off Warning-Check for Project Specific Encoding
+ *******************************************************************************/
+package org.eclipse.core.tests.resources;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.eclipse.core.internal.resources.PreferenceInitializer;
+import org.eclipse.core.internal.resources.ValidateProjectEncoding;
+import org.eclipse.core.internal.utils.Messages;
+import org.eclipse.core.resources.*;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.osgi.util.NLS;
+import org.hamcrest.*;
+import org.junit.Test;
+
+/**
+ * Test for integration of marker
+ * {@link org.eclipse.core.resources.ResourcesPlugin#PREF_MISSING_ENCODING_MARKER_SEVERITY}.
+ */
+public class ProjectEncodingTest extends ResourceTest {
+
+	private static final int IGNORE = -1;
+
+	private IProject project;
+
+	@Override
+	protected void tearDown() throws Exception {
+		if (project != null) {
+			project.delete(true, null);
+		}
+		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).putInt(
+				ResourcesPlugin.PREF_MISSING_ENCODING_MARKER_SEVERITY,
+				PreferenceInitializer.PREF_MISSING_ENCODING_MARKER_SEVERITY_DEFAULT);
+		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).flush();
+
+		super.tearDown();
+	}
+
+	@Test
+	public void test_ProjectWithoutEncoding_PreferenceIsSetToIgnore_NoMarkerIsPlaced() throws Exception {
+		givenPreferenceIsSetTo(IGNORE);
+		whenProjectIsCreated();
+		whenProjectSpecificEncodingWasRemoved();
+		thenProjectHasNoEncodingMarker();
+	}
+
+	@Test
+	public void test_ProjectWithoutEncoding_PreferenceIsSetToInfo_InfoMarkerIsPlaced() throws Exception {
+		verifyMarkerIsAddedToProjectWithNoEncodingIfPreferenceIsSetTo(IMarker.SEVERITY_INFO);
+	}
+
+	@Test
+	public void test_ProjectWithoutEncoding_PreferenceIsSetToWarning_WarningMarkerIsPlaced() throws Exception {
+		verifyMarkerIsAddedToProjectWithNoEncodingIfPreferenceIsSetTo(IMarker.SEVERITY_WARNING);
+	}
+
+	@Test
+	public void test_ProjectWithoutEncoding_PreferenceIsSetToError_ErrorMarkerIsPlaced() throws Exception {
+		verifyMarkerIsAddedToProjectWithNoEncodingIfPreferenceIsSetTo(IMarker.SEVERITY_ERROR);
+	}
+
+	private void verifyMarkerIsAddedToProjectWithNoEncodingIfPreferenceIsSetTo(int severity) throws Exception {
+		givenPreferenceIsSetTo(severity);
+		whenProjectIsCreated();
+		whenProjectSpecificEncodingWasRemoved();
+		thenProjectHasEncodingMarkerOfSeverity(severity);
+	}
+
+	private void verifyNoMarkerIsAddedToProjectWithEncodingIfPreferenceIsSetTo(int severity) throws Exception {
+		givenPreferenceIsSetTo(severity);
+		whenProjectIsCreated();
+		whenProjectSpecificEncodingWasSet();
+		thenProjectHasNoEncodingMarker();
+	}
+
+	@Test
+	public void test_ProjectWithEncoding_PreferenceIsSetToIgnore_NoMarkerIsPlaced() throws Exception {
+		verifyNoMarkerIsAddedToProjectWithEncodingIfPreferenceIsSetTo(IGNORE);
+	}
+
+	@Test
+	public void test_ProjectWithEncoding_PreferenceIsSetToInfo_NoMarkerIsPlaced() throws Exception {
+		verifyNoMarkerIsAddedToProjectWithEncodingIfPreferenceIsSetTo(IMarker.SEVERITY_INFO);
+	}
+
+	@Test
+	public void test_ProjectWithEncoding_PreferenceIsSetToWarning_NoMarkerIsPlaced() throws Exception {
+		verifyNoMarkerIsAddedToProjectWithEncodingIfPreferenceIsSetTo(IMarker.SEVERITY_WARNING);
+	}
+
+	@Test
+	public void test_ProjectWithEncoding_PreferenceIsSetToError_NoMarkerIsPlaced() throws Exception {
+		verifyNoMarkerIsAddedToProjectWithEncodingIfPreferenceIsSetTo(IMarker.SEVERITY_ERROR);
+	}
+
+	@Test
+	public void test_ProjectWithoutEncoding_PreferenceChanges_MarkerIsReplacedAccordingly() throws Exception {
+		givenPreferenceIsSetTo(IMarker.SEVERITY_WARNING);
+		whenProjectIsCreated();
+		whenProjectSpecificEncodingWasRemoved();
+		thenProjectHasEncodingMarkerOfSeverity(IMarker.SEVERITY_WARNING);
+
+		whenPreferenceIsChangedTo(IMarker.SEVERITY_INFO);
+		thenProjectHasEncodingMarkerOfSeverity(IMarker.SEVERITY_INFO);
+
+		whenPreferenceIsChangedTo(IMarker.SEVERITY_ERROR);
+		thenProjectHasEncodingMarkerOfSeverity(IMarker.SEVERITY_ERROR);
+
+		whenPreferenceIsChangedTo(IGNORE);
+		thenProjectHasNoEncodingMarker();
+
+		whenPreferenceIsChangedTo(IMarker.SEVERITY_WARNING);
+		thenProjectHasEncodingMarkerOfSeverity(IMarker.SEVERITY_WARNING);
+	}
+
+	@Test
+	public void test_ProjectEncodingWasAdded_ProblemMarkerIsGone() throws Exception {
+		givenPreferenceIsSetTo(IMarker.SEVERITY_WARNING);
+		whenProjectIsCreated();
+		whenProjectSpecificEncodingWasRemoved();
+
+		thenProjectHasEncodingMarkerOfSeverity(IMarker.SEVERITY_WARNING);
+
+		whenProjectSpecificEncodingWasSet();
+
+		thenProjectHasNoEncodingMarker();
+	}
+
+	private void whenPreferenceIsChangedTo(int severity) throws Exception {
+		givenPreferenceIsSetTo(severity);
+	}
+
+	private void givenPreferenceIsSetTo(int value) throws Exception {
+		IEclipsePreferences node = InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES);
+		node.putInt(ResourcesPlugin.PREF_MISSING_ENCODING_MARKER_SEVERITY, value);
+		node.flush();
+		Job.getJobManager().join(ValidateProjectEncoding.class, getMonitor());
+	}
+
+	private void whenProjectIsCreated() {
+		project = ResourcesPlugin.getWorkspace().getRoot().getProject(getUniqueString());
+		ensureExistsInWorkspace(project, true);
+	}
+
+	private void whenProjectSpecificEncodingWasRemoved() throws Exception {
+		project.setDefaultCharset(null, null);
+		buildAndWaitForBuildFinish();
+	}
+
+	private void whenProjectSpecificEncodingWasSet() throws Exception {
+		project.setDefaultCharset("UTF-8", null);
+		buildAndWaitForBuildFinish();
+	}
+
+	private void thenProjectHasNoEncodingMarker() throws Exception {
+		IMarker[] markers = project.findMarkers(ValidateProjectEncoding.MARKER_TYPE, false, IResource.DEPTH_ONE);
+		assertEquals("Expected to find no marker for project specific file encoding", 0, markers.length);
+	}
+
+	private void thenProjectHasEncodingMarkerOfSeverity(int expectedSeverity) throws Exception {
+		assertThat(project, hasEncodingMarkerOfSeverity(expectedSeverity));
+	}
+
+	private BaseMatcher<IProject> hasEncodingMarkerOfSeverity(final int expectedSeverity) {
+		return new DiagnosingMatcher<>() {
+
+			@Override
+			public boolean matches(Object item, Description mismatchDescription) {
+				IProject theProject = (IProject) item;
+
+				try {
+					IMarker[] markers = theProject.findMarkers(ValidateProjectEncoding.MARKER_TYPE, false,
+							IResource.DEPTH_ONE);
+					if (markers.length == 1) {
+						IMarker marker = markers[0];
+						String[] attributeNames = { IMarker.MESSAGE, IMarker.SEVERITY, IMarker.LOCATION };
+						Object[] values = marker.getAttributes(attributeNames);
+
+						boolean msgOk = getExpectedMarkerMessage().equals(values[0]);
+						boolean sevOk = ((Integer) expectedSeverity).equals(values[1]);
+						boolean locOk = project.getFullPath().toString().equals(values[2]);
+
+						if (!msgOk) {
+							mismatchDescription.appendText("\n has marker message: " + values[0]);
+						}
+						if (!sevOk) {
+							mismatchDescription.appendText("\n has marker severity: " + values[1]);
+						}
+						if (!locOk) {
+							mismatchDescription.appendText("\n has marker location: " + values[2]);
+						}
+
+						return msgOk && sevOk && locOk;
+					}
+					mismatchDescription.appendText("\n has " + markers.length + " encoding markers");
+
+				} catch (CoreException e) {
+					mismatchDescription.appendText("\n cannot access markers: " + e.getMessage());
+				}
+				return false;
+			}
+
+			@Override
+			public void describeTo(Description description) {
+				description.appendText("\n has marker of message: '" + getExpectedMarkerMessage() + "'");
+				description.appendText("\n has marker severity: " + expectedSeverity);
+				description.appendText("\n has location: <path of the project>");
+			}
+
+			private String getExpectedMarkerMessage() {
+				return NLS.bind(Messages.resources_checkExplicitEncoding_problemText, project.getName());
+			}
+
+		};
+	}
+
+	private void buildAndWaitForBuildFinish() {
+		buildResources();
+		waitForBuild();
+	}
+
+}


### PR DESCRIPTION
Introduces a new preference that enables to specify if and using which
severity markers shall be added in case of missing project-specific
encoding settings.

This is the PR of the fork for issue [#166](https://github.com/eclipse-platform/eclipse.platform.resources/issues/166)

### Todo
* @merks I could use some help/hints w/ further unit tests.
** i.e. where am I supposed to integrate tests for this? Can I add an extra test class just for this?
* @merks Maybe you have an idea for this: I cannot seem to delete the "project encoding" markers.
** If I delete them, the pref change listener re-creates them right away, so that to the user this has the effect of "not deleted at all"
*** I checked the event type, the build kind and the delta type - but they're all exactly the same for both cases:
**** I delete the marker from the Problems view
**** I re-build (or clean and rebuild) the projects on the workspace
*** What I want is to be able to delete the markers - and then have a project-rebuild re-add the markers again.
*** Turning off "on access refresh" had no effect here.
*** I'm out of ideas atm.

### Here's what I did
#### Change
* Added the preference with a default value (which is WARN (as it was the severity before)
* Added a pref change listener as a service to remove/add/update the markers accordingly
* Added a severity provider class b/c I need access to the severity in both
** the new pref change listener I added and
** the existing `ValidateProjectEncoding` class
* Tested that provider using Mockito (which I added to the dependencies of the resources test fragment)
** Since I cannot mock a static constant (static methods can be mocked w/ Mockito, but constants apparently can't), I decided to use the same package for the test class so that I can override the "package-protected" getter for the InstanceScope.

#### Manual Integration Test
* Tested w/ my fork of [eclipse.platform.ui](https://github.com/ingomohr/eclipse.platform.ui)
* Modifying the severity (except "ignore") updated the markers as expected
* Modifying the severity to "ignore" removed the markers as expected
* Modifying the severity from "ignore" to something else added the markers were needed

Thank you in advance for having a look at the PR!

Kind regards
Ingo