### PR TITLE
Filter all resources of nested projects from their parent

### DIFF
--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Project.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Project.java
@@ -470,6 +470,26 @@ public class Project extends Container implements IProject {
 	}
 
 	@Override
+	public IProject[] getContainedProjects() throws CoreException {
+		checkAccessible(getFlags(getResourceInfo(false, false)));
+		final IPath location = getLocation();
+		if (location != null) {
+			return Arrays.stream(getWorkspace().getRoot().getProjects(IContainer.INCLUDE_HIDDEN))
+					.filter((IProject p) -> {
+						if (p == this) {
+							return false;
+						}
+						IPath pLocation = p.getLocation();
+						if (pLocation != null && location.isPrefixOf(pLocation)) {
+							return true;
+						}
+						return false;
+					}).toArray(IProject[]::new);
+		}
+		return new IProject[] {};
+	}
+
+	@Override
 	public void clearCachedDynamicReferences() {
 		ResourceInfo info = getResourceInfo(false, false);
 		if (info == null) {

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Resource.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Resource.java
@@ -26,6 +26,7 @@ package org.eclipse.core.internal.resources;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
+import java.util.stream.Collectors;
 import org.eclipse.core.filesystem.*;
 import org.eclipse.core.filesystem.URIUtil;
 import org.eclipse.core.filesystem.provider.FileInfo;
@@ -1993,6 +1994,15 @@ public abstract class Resource extends PlatformObject implements IResource, ICor
 			}
 			firstSegment = false;
 		} while (relativePath.segmentCount() > 0);
+
+		// filter roots of projects nested within this project
+		Set<String> projectChildren = Arrays.stream(project.getContainedProjects())
+				.map(IProject::getLocation)
+				.filter(c -> c.removeLastSegments(1).equals(getLocation()))
+				.map(IPath::lastSegment).collect(Collectors.toSet());
+		list = Arrays.stream(list)
+				.filter(f -> !projectChildren.contains(f.getName()))
+				.toArray(IFileInfo[]::new);
 
 		if ((currentIncludeFilters.size() > 0) || (currentExcludeFilters.size() > 0)) {
 			try {

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/IProject.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/IProject.java
@@ -1056,6 +1056,22 @@ public interface IProject extends IContainer, IAdaptable {
 	void setDescription(IProjectDescription description, int updateFlags, IProgressMonitor monitor) throws CoreException;
 
 	/**
+	 * Get projects contained within this project.
+	 *
+	 * @return an array of all the other projects known to reside within the
+	 *         filesystem tree of this project.
+	 * @exception CoreException if this method fails. Reasons include:
+	 *                          <ul>
+	 *                          <li>This project does not exist.</li>
+	 *                          <li>This project is not open.</li>
+	 *                          </ul>
+	 * @since 3.18
+	 */
+	default IProject[] getContainedProjects() throws CoreException {
+		return new IProject[] {};
+	}
+
+	/**
 	 * Returns line separator appropriate for new files in the given project.
 	 * <p>
 	 * This method uses the following algorithm to determine the line separator to


### PR DESCRIPTION
This way resources only show up in the project closest to them (shortest path to parent)
The "Open Resource" dialog no longer offers to open the same resources multiple times,
"File Search" no longer finds matches in the same file multiple times (in multiple projects)
This greatly improves the user experience for Gradle and Maven projects which normally lay out
their related projects in a hierarchial way.

Some usecases that relied on the previous behavior may degrade as a result,
which usecases these are and if the degradation should be considered a defect is yet to be determined.

Signed-off-by: Christoph Obexer <cobexer@gmail.com>