### PR TITLE
Add Preference to turn off check for project specific encoding (#166)

### DIFF
--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/PreferenceInitializer.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/PreferenceInitializer.java
@@ -11,6 +11,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     James Blackburn (Broadcom Corp.) - ongoing development
+ *     Ingo Mohr - Issue #166 - Add Preference to Turn Off Warning-Check for Project Specific Encoding
  *******************************************************************************/
 package org.eclipse.core.internal.resources;
 
@@ -50,6 +51,13 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 	 * @since 3.12
 	 */
 	public static final int PREF_MISSING_NATURE_MARKER_SEVERITY_DEFAULT = IMarker.SEVERITY_WARNING;
+	/**
+	 * Default setting for
+	 * {@value ResourcesPlugin#PREF_MISSING_ENCODING_MARKER_SEVERITY}.
+	 *
+	 * @since 3.18
+	 */
+	public static final int PREF_MISSING_ENCODING_MARKER_SEVERITY_DEFAULT = IMarker.SEVERITY_WARNING;
 
 	/**
 	 * @since 3.13
@@ -76,6 +84,8 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 		node.putInt(ResourcesPlugin.PREF_MAX_BUILD_ITERATIONS, PREF_MAX_BUILD_ITERATIONS_DEFAULT);
 		node.putBoolean(ResourcesPlugin.PREF_DEFAULT_BUILD_ORDER, PREF_DEFAULT_BUILD_ORDER_DEFAULT);
 		node.putInt(ResourcesPlugin.PREF_MISSING_NATURE_MARKER_SEVERITY, PREF_MISSING_NATURE_MARKER_SEVERITY_DEFAULT);
+		node.putInt(ResourcesPlugin.PREF_MISSING_ENCODING_MARKER_SEVERITY,
+				PREF_MISSING_ENCODING_MARKER_SEVERITY_DEFAULT);
 
 
 		// history store defaults

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/ValidateProjectEncoding.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/ValidateProjectEncoding.java
@@ -11,6 +11,7 @@
  * Contributors:
  *     Simeon Andreev - initial API and implementation
  *     Christoph Läubrich - Issue #80 - CharsetManager access the ResourcesPlugin.getWorkspace before init
+ *     Ingo Mohr - Issue #166 - Add Preference to Turn Off Warning-Check for Project Specific Encoding
  *******************************************************************************/
 package org.eclipse.core.internal.resources;
 
@@ -18,6 +19,8 @@ import java.util.*;
 import org.eclipse.core.internal.utils.Messages;
 import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.*;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.osgi.util.NLS;
 
 /**
@@ -83,9 +86,10 @@ public class ValidateProjectEncoding extends InternalWorkspaceJob {
 	static void updateMissingEncodingMarker(IProject project) {
 		try {
 			if (project.isAccessible() && !project.isHidden()) {
+				int severity = getSeverity();
 				String defaultCharset = getDefaultCharset(project);
-				if (defaultCharset == null) {
-					createEncodingMarker(project);
+				if (severity >= 0 && defaultCharset == null) {
+					createOrUpdateMissingEncodingMarker(project, severity);
 				} else {
 					deleteEncodingMarkers(project);
 				}
@@ -93,6 +97,22 @@ public class ValidateProjectEncoding extends InternalWorkspaceJob {
 		} catch (CoreException e) {
 			logException(e);
 		}
+	}
+
+	/**
+	 * Returns the current severity for
+	 * {@link ResourcesPlugin#PREF_MISSING_ENCODING_MARKER_SEVERITY}.
+	 *
+	 * @return current severity. Default value is nothing else is specified.
+	 */
+	private static int getSeverity() {
+		int severity = PreferenceInitializer.PREF_MISSING_ENCODING_MARKER_SEVERITY_DEFAULT;
+		IEclipsePreferences node = InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES);
+		if (node != null) {
+			severity = node.getInt(ResourcesPlugin.PREF_MISSING_ENCODING_MARKER_SEVERITY,
+					PreferenceInitializer.PREF_MISSING_ENCODING_MARKER_SEVERITY_DEFAULT);
+		}
+		return severity;
 	}
 
 	private static boolean shouldScheduleValidation(IProject project) {
@@ -125,25 +145,35 @@ public class ValidateProjectEncoding extends InternalWorkspaceJob {
 		return defaultCharset;
 	}
 
-	private static void createEncodingMarker(IProject project) throws CoreException {
+	private static void createOrUpdateMissingEncodingMarker(IProject project, int severity) throws CoreException {
 		String message = NLS.bind(Messages.resources_checkExplicitEncoding_problemText, project.getName());
 
-		String[] attributeNames = { IMarker.MESSAGE, IMarker.SEVERITY, IMarker.LOCATION };
-		Object[] attributevalues = { message, IMarker.SEVERITY_WARNING, project.getFullPath().toString() };
+		String[] attributeNames = { IMarker.MESSAGE, IMarker.LOCATION };
+		Object[] attributevalues = { message, project.getFullPath().toString() };
 
 		IMarker[] existing = project.findMarkers(MARKER_TYPE, false, IResource.DEPTH_ONE);
 		for (IMarker marker : existing) {
 			Object[] markerValues = marker.getAttributes(attributeNames);
 			if (Arrays.equals(attributevalues, markerValues)) {
+				updateMarkerSeverity(marker, severity);
 				return;
 			}
 		}
 
 		Map<String, Object> attributes = new HashMap<>();
 		for (int i = 0; i < attributeNames.length; i++) {
-		    attributes.put(attributeNames[i], attributevalues[i]);
+			attributes.put(attributeNames[i], attributevalues[i]);
 		}
+		attributes.put(IMarker.SEVERITY, severity);
 		project.createMarker(MARKER_TYPE, attributes);
+	}
+
+	private static void updateMarkerSeverity(IMarker marker, int severity) throws CoreException {
+		int currentSeverity = (int) marker.getAttribute(IMarker.SEVERITY);
+
+		if (currentSeverity != severity) {
+			marker.setAttribute(IMarker.SEVERITY, severity);
+		}
 	}
 
 	private static void deleteEncodingMarkers(IProject project) throws CoreException {

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/utils/Messages.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/utils/Messages.java
@@ -12,9 +12,10 @@
  *     IBM - Initial API and implementation
  *     Serge Beauchamp (Freescale Semiconductor) - [252996] add resource filtering
  *     Serge Beauchamp (Freescale Semiconductor) - [229633] Group and Project Path Variable Support
- * Francis Lynch (Wind River) - [301563] Save and load tree snapshots
- * Martin Oberhuber (Wind River) - [306575] Save snapshot location with project
- * Mikael Barbero (Eclipse Foundation) - [286681] handle WAIT_ABANDONED_0 return value
+ *     Francis Lynch (Wind River) - [301563] Save and load tree snapshots
+ *     Martin Oberhuber (Wind River) - [306575] Save snapshot location with project
+ *     Mikael Barbero (Eclipse Foundation) - [286681] handle WAIT_ABANDONED_0 return value
+ *     Ingo Mohr - Issue #166 - Add Preference to Turn Off Warning-Check for Project Specific Encoding
  *******************************************************************************/
 package org.eclipse.core.internal.utils;
 
@@ -334,6 +335,7 @@ public class Messages extends NLS {
 	public static String WM_mutexAbandoned;
 
 	public static String updateUnknownNatureMarkers;
+	public static String updateMissingProjectEncodingMarkers;
 
 	static {
 		// initialize resource bundles

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/utils/messages.properties
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/utils/messages.properties
@@ -122,6 +122,7 @@ preferences_saveProblems=Exception occurred while saving project preferences: {0
 preferences_syncException=Exception occurred while synchronizing node: {0}.
 
 updateUnknownNatureMarkers=Update markers for unknown nature on projects
+updateMissingProjectEncodingMarkers="Update markers for missing project encoding
 
 projRead_badLinkName = Names ''{0}'' and ''{1}'' detected for a single link.  Using ''{0}''.
 projRead_badLinkType2 = Types ''{0}'' and ''{1}'' detected for a single link.  Using ''{0}''.

--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/ResourcesPlugin.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/ResourcesPlugin.java
@@ -17,6 +17,7 @@
  *     Lars Vogel <Lars.Vogel@vogella.com> - Bug 473427
  *     Christoph Läubrich 	- Issue #52 - Make ResourcesPlugin more dynamic and better handling early start-up
  *     						- Issue #68 - Use DS for CheckMissingNaturesListener
+ *     Ingo Mohr - Issue #166 - Add Preference to Turn Off Warning-Check for Project Specific Encoding
  *******************************************************************************/
 package org.eclipse.core.resources;
 
@@ -354,6 +355,14 @@ public final class ResourcesPlugin extends Plugin {
 	 * @since 3.13
 	 */
 	public static final String PREF_MISSING_NATURE_MARKER_SEVERITY = "missingNatureMarkerSeverity"; //$NON-NLS-1$
+
+	/**
+	 * Name of a preference for configuring the marker severity in case project does
+	 * not specify its encoding
+	 *
+	 * @since 3.18
+	 */
+	public static final String PREF_MISSING_ENCODING_MARKER_SEVERITY = "missingEncodingMarkerSeverity"; //$NON-NLS-1$
 
 	/**
 	 * Name of the preference to set max number of concurrent jobs running the workspace build.

--- a/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/AllTests.java
+++ b/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/AllTests.java
@@ -10,6 +10,7 @@
  *
  *  Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Ingo Mohr - Issue #166 - Add Preference to Turn Off Warning-Check for Project Specific Encoding
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
@@ -24,7 +25,8 @@ import org.junit.runners.Suite;
 		IResourceChangeListenerTest.class, IResourceDeltaTest.class, IResourceTest.class, ISynchronizerTest.class,
 		IWorkspaceRootTest.class, IWorkspaceTest.class, LinkedResourceTest.class,
 		LinkedResourceWithPathVariableTest.class, LinkedResourceSyncMoveAndCopyTest.class, MarkerSetTest.class,
-		MarkerTest.class, NatureTest.class, NonLocalLinkedResourceTest.class, ProjectOrderTest.class,
+		MarkerTest.class, NatureTest.class, NonLocalLinkedResourceTest.class, ProjectEncodingTest.class,
+		ProjectOrderTest.class,
 		ProjectScopeTest.class, ProjectSnapshotTest.class, ResourceAttributeTest.class, ResourceURLTest.class,
 		TeamPrivateMemberTest.class, WorkspaceTest.class })
 public class AllTests {

--- a/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectEncodingTest.java
+++ b/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectEncodingTest.java
@@ -1,0 +1,240 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Ingo Mohr - Issue #166 - Add Preference to Turn Off Warning-Check for Project Specific Encoding
+ *******************************************************************************/
+package org.eclipse.core.tests.resources;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.eclipse.core.internal.resources.PreferenceInitializer;
+import org.eclipse.core.internal.resources.ValidateProjectEncoding;
+import org.eclipse.core.internal.utils.Messages;
+import org.eclipse.core.resources.*;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.osgi.util.NLS;
+import org.hamcrest.*;
+import org.junit.Test;
+
+/**
+ * Test for integration of marker
+ * {@link org.eclipse.core.resources.ResourcesPlugin#PREF_MISSING_ENCODING_MARKER_SEVERITY}.
+ */
+public class ProjectEncodingTest extends ResourceTest {
+
+	private static final int IGNORE = -1;
+
+	private IProject project;
+
+	@Override
+	protected void tearDown() throws Exception {
+		if (project != null) {
+			project.delete(true, null);
+		}
+		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).putInt(
+				ResourcesPlugin.PREF_MISSING_ENCODING_MARKER_SEVERITY,
+				PreferenceInitializer.PREF_MISSING_ENCODING_MARKER_SEVERITY_DEFAULT);
+		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).flush();
+		super.tearDown();
+		getWorkspace().getRoot().refreshLocal(IResource.DEPTH_INFINITE, null);
+		ensureDoesNotExistInWorkspace(getWorkspace().getRoot());
+
+		System.out.println("teardown done");
+
+	}
+
+	@Test
+	public void test_ProjectWithoutEncoding_PreferenceIsSetToIgnore_NoMarkerIsPlaced() throws Exception {
+		givenPreferenceIsSetTo(IGNORE);
+		whenProjectIsCreated();
+		whenProjectSpecificEncodingWasRemoved();
+		thenProjectHasNoEncodingMarker();
+	}
+
+	@Test
+	public void test_ProjectWithoutEncoding_PreferenceIsSetToInfo_InfoMarkerIsPlaced() throws Exception {
+		verifyMarkerIsAddedToProjectWithNoEncodingIfPreferenceIsSetTo(IMarker.SEVERITY_INFO);
+	}
+
+	@Test
+	public void test_ProjectWithoutEncoding_PreferenceIsSetToWarning_WarningMarkerIsPlaced() throws Exception {
+		verifyMarkerIsAddedToProjectWithNoEncodingIfPreferenceIsSetTo(IMarker.SEVERITY_WARNING);
+	}
+
+	@Test
+	public void test_ProjectWithoutEncoding_PreferenceIsSetToError_ErrorMarkerIsPlaced() throws Exception {
+		verifyMarkerIsAddedToProjectWithNoEncodingIfPreferenceIsSetTo(IMarker.SEVERITY_ERROR);
+	}
+
+	private void verifyMarkerIsAddedToProjectWithNoEncodingIfPreferenceIsSetTo(int severity) throws Exception {
+		givenPreferenceIsSetTo(severity);
+		whenProjectIsCreated();
+		whenProjectSpecificEncodingWasRemoved();
+		thenProjectHasEncodingMarkerOfSeverity(severity);
+	}
+
+	private void verifyNoMarkerIsAddedToProjectWithEncodingIfPreferenceIsSetTo(int severity) throws Exception {
+		givenPreferenceIsSetTo(severity);
+		whenProjectIsCreated();
+		whenProjectSpecificEncodingWasSet();
+		thenProjectHasNoEncodingMarker();
+	}
+
+	@Test
+	public void test_ProjectWithEncoding_PreferenceIsSetToIgnore_NoMarkerIsPlaced() throws Exception {
+		verifyNoMarkerIsAddedToProjectWithEncodingIfPreferenceIsSetTo(IGNORE);
+	}
+
+	@Test
+	public void test_ProjectWithEncoding_PreferenceIsSetToInfo_NoMarkerIsPlaced() throws Exception {
+		verifyNoMarkerIsAddedToProjectWithEncodingIfPreferenceIsSetTo(IMarker.SEVERITY_INFO);
+	}
+
+	@Test
+	public void test_ProjectWithEncoding_PreferenceIsSetToWarning_NoMarkerIsPlaced() throws Exception {
+		verifyNoMarkerIsAddedToProjectWithEncodingIfPreferenceIsSetTo(IMarker.SEVERITY_WARNING);
+	}
+
+	@Test
+	public void test_ProjectWithEncoding_PreferenceIsSetToError_NoMarkerIsPlaced() throws Exception {
+		verifyNoMarkerIsAddedToProjectWithEncodingIfPreferenceIsSetTo(IMarker.SEVERITY_ERROR);
+	}
+
+	@Test
+	public void test_ProjectWithoutEncoding_PreferenceChanges_MarkerIsReplacedAccordingly() throws Exception {
+		givenPreferenceIsSetTo(IMarker.SEVERITY_WARNING);
+		whenProjectIsCreated();
+		whenProjectSpecificEncodingWasRemoved();
+		thenProjectHasEncodingMarkerOfSeverity(IMarker.SEVERITY_WARNING);
+
+		whenPreferenceIsChangedTo(IMarker.SEVERITY_INFO);
+		thenProjectHasEncodingMarkerOfSeverity(IMarker.SEVERITY_INFO);
+
+		whenPreferenceIsChangedTo(IMarker.SEVERITY_ERROR);
+		thenProjectHasEncodingMarkerOfSeverity(IMarker.SEVERITY_ERROR);
+
+		whenPreferenceIsChangedTo(IGNORE);
+		thenProjectHasNoEncodingMarker();
+
+		whenPreferenceIsChangedTo(IMarker.SEVERITY_WARNING);
+		thenProjectHasEncodingMarkerOfSeverity(IMarker.SEVERITY_WARNING);
+	}
+
+	@Test
+	public void test_ProjectEncodingWasAdded_ProblemMarkerIsGone() throws Exception {
+		givenPreferenceIsSetTo(IMarker.SEVERITY_WARNING);
+		whenProjectIsCreated();
+		whenProjectSpecificEncodingWasRemoved();
+
+		thenProjectHasEncodingMarkerOfSeverity(IMarker.SEVERITY_WARNING);
+
+		whenProjectSpecificEncodingWasSet();
+
+		thenProjectHasNoEncodingMarker();
+	}
+
+	private void whenPreferenceIsChangedTo(int severity) throws Exception {
+		givenPreferenceIsSetTo(severity);
+	}
+
+	private void givenPreferenceIsSetTo(int value) throws Exception {
+		IEclipsePreferences node = InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES);
+		node.putInt(ResourcesPlugin.PREF_MISSING_ENCODING_MARKER_SEVERITY, value);
+		node.flush();
+		Job.getJobManager().join(ValidateProjectEncoding.class, getMonitor());
+	}
+
+	private void whenProjectIsCreated() {
+		project = ResourcesPlugin.getWorkspace().getRoot().getProject(getUniqueString());
+		ensureExistsInWorkspace(project, true);
+	}
+
+	private void whenProjectSpecificEncodingWasRemoved() throws Exception {
+		project.setDefaultCharset(null, null);
+		buildAndWaitForBuildFinish();
+	}
+
+	private void whenProjectSpecificEncodingWasSet() throws Exception {
+		project.setDefaultCharset("UTF-8", null);
+		buildAndWaitForBuildFinish();
+	}
+
+	private void thenProjectHasNoEncodingMarker() throws Exception {
+		IMarker[] markers = project.findMarkers(ValidateProjectEncoding.MARKER_TYPE, false, IResource.DEPTH_ONE);
+		assertEquals("Expected to find no marker for project specific file encoding", 0, markers.length);
+	}
+
+	private void thenProjectHasEncodingMarkerOfSeverity(int expectedSeverity) throws Exception {
+		assertThat(project, hasEncodingMarkerOfSeverity(expectedSeverity));
+	}
+
+	private BaseMatcher<IProject> hasEncodingMarkerOfSeverity(final int expectedSeverity) {
+		return new DiagnosingMatcher<>() {
+
+			@Override
+			public boolean matches(Object item, Description mismatchDescription) {
+				IProject theProject = (IProject) item;
+
+				try {
+					IMarker[] markers = theProject.findMarkers(ValidateProjectEncoding.MARKER_TYPE, false,
+							IResource.DEPTH_ONE);
+					if (markers.length == 1) {
+						IMarker marker = markers[0];
+						String[] attributeNames = { IMarker.MESSAGE, IMarker.SEVERITY, IMarker.LOCATION };
+						Object[] values = marker.getAttributes(attributeNames);
+
+						boolean msgOk = getExpectedMarkerMessage().equals(values[0]);
+						boolean sevOk = ((Integer) expectedSeverity).equals(values[1]);
+						boolean locOk = project.getFullPath().toString().equals(values[2]);
+
+						if (!msgOk) {
+							mismatchDescription.appendText("\n has marker message: " + values[0]);
+						}
+						if (!sevOk) {
+							mismatchDescription.appendText("\n has marker severity: " + values[1]);
+						}
+						if (!locOk) {
+							mismatchDescription.appendText("\n has marker location: " + values[2]);
+						}
+
+						return msgOk && sevOk && locOk;
+					}
+					mismatchDescription.appendText("\n has " + markers.length + " encoding markers");
+
+				} catch (CoreException e) {
+					mismatchDescription.appendText("\n cannot access markers: " + e.getMessage());
+				}
+				return false;
+			}
+
+			@Override
+			public void describeTo(Description description) {
+				description.appendText("\n has marker of message: '" + getExpectedMarkerMessage() + "'");
+				description.appendText("\n has marker severity: " + expectedSeverity);
+				description.appendText("\n has location: <path of the project>");
+			}
+
+			private String getExpectedMarkerMessage() {
+				return NLS.bind(Messages.resources_checkExplicitEncoding_problemText, project.getName());
+			}
+
+		};
+	}
+
+	private void buildAndWaitForBuildFinish() {
+		buildResources();
+		waitForBuild();
+	}
+
+}


### PR DESCRIPTION
I don't want to merge it. Just showing we don't need any OSGI components etc, compared to https://github.com/eclipse-platform/eclipse.platform.resources/pull/167