### PR TITLE
Fix all warnings for missing project encoding (#168)

### DIFF
--- a/bundles/org.eclipse.core.filesystem.linux.aarch64/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.core.filesystem.linux.aarch64/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.eclipse.core.filesystem.linux.aarch64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.filesystem.linux.aarch64/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %fragmentName
 Bundle-SymbolicName: org.eclipse.core.filesystem.linux.aarch64;singleton:=true
-Bundle-Version: 1.4.100.qualifier
+Bundle-Version: 1.4.200.qualifier
 Bundle-Vendor: %providerName
 Fragment-Host: org.eclipse.core.filesystem;bundle-version="[1.1.0,2.0.0)"
 Bundle-Localization: fragment

--- a/bundles/org.eclipse.core.filesystem.linux.aarch64/pom.xml
+++ b/bundles/org.eclipse.core.filesystem.linux.aarch64/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.core.filesystem.linux.aarch64</artifactId>
-  <version>1.4.100-SNAPSHOT</version>
+  <version>1.4.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/bundles/org.eclipse.core.filesystem.linux.loongarch64/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.core.filesystem.linux.loongarch64/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.eclipse.core.filesystem.linux.loongarch64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.filesystem.linux.loongarch64/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %fragmentName
 Bundle-SymbolicName: org.eclipse.core.filesystem.linux.loongarch64;singleton:=true
-Bundle-Version: 1.4.100.qualifier
+Bundle-Version: 1.4.200.qualifier
 Bundle-Vendor: %providerName
 Fragment-Host: org.eclipse.core.filesystem;bundle-version="[1.1.0,2.0.0)"
 Bundle-Localization: fragment

--- a/bundles/org.eclipse.core.filesystem.linux.loongarch64/pom.xml
+++ b/bundles/org.eclipse.core.filesystem.linux.loongarch64/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.core.filesystem.linux.loongarch64</artifactId>
-  <version>1.4.100-SNAPSHOT</version>
+  <version>1.4.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/bundles/org.eclipse.core.filesystem.linux.ppc64le/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.core.filesystem.linux.ppc64le/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.eclipse.core.filesystem.linux.ppc64le/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.filesystem.linux.ppc64le/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %fragmentName
 Bundle-SymbolicName: org.eclipse.core.filesystem.linux.ppc64le;singleton:=true
-Bundle-Version: 1.4.100.qualifier
+Bundle-Version: 1.4.200.qualifier
 Bundle-Vendor: %providerName
 Fragment-Host: org.eclipse.core.filesystem;bundle-version="[1.1.0,2.0.0)"
 Bundle-Localization: fragment

--- a/bundles/org.eclipse.core.filesystem.linux.ppc64le/pom.xml
+++ b/bundles/org.eclipse.core.filesystem.linux.ppc64le/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.core.filesystem.linux.ppc64le</artifactId>
-  <version>1.4.100-SNAPSHOT</version>
+  <version>1.4.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/bundles/org.eclipse.core.filesystem.linux.x86_64/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.core.filesystem.linux.x86_64/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.eclipse.core.filesystem.linux.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.filesystem.linux.x86_64/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %fragmentName
 Bundle-SymbolicName: org.eclipse.core.filesystem.linux.x86_64; singleton:=true
-Bundle-Version: 1.2.300.qualifier
+Bundle-Version: 1.2.400.qualifier
 Bundle-Vendor: %providerName
 Fragment-Host: org.eclipse.core.filesystem;bundle-version="[1.7.200,2.0.0)"
 Bundle-Localization: fragment

--- a/bundles/org.eclipse.core.filesystem.linux.x86_64/pom.xml
+++ b/bundles/org.eclipse.core.filesystem.linux.x86_64/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.core.filesystem.linux.x86_64</artifactId>
-  <version>1.2.300-SNAPSHOT</version>
+  <version>1.2.400-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/bundles/org.eclipse.core.filesystem.macosx/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.core.filesystem.macosx/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.eclipse.core.filesystem.macosx/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.filesystem.macosx/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %fragmentName
 Bundle-SymbolicName: org.eclipse.core.filesystem.macosx; singleton:=true
-Bundle-Version: 1.3.300.qualifier
+Bundle-Version: 1.3.400.qualifier
 Bundle-Vendor: %providerName
 Fragment-Host: org.eclipse.core.filesystem;bundle-version="[1.7.200,2.0.0)"
 Bundle-Localization: fragment

--- a/bundles/org.eclipse.core.filesystem.macosx/pom.xml
+++ b/bundles/org.eclipse.core.filesystem.macosx/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.core.filesystem.macosx</artifactId>
-  <version>1.3.300-SNAPSHOT</version>
+  <version>1.3.400-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/bundles/org.eclipse.core.filesystem.win32.x86_64/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.core.filesystem.win32.x86_64/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.eclipse.core.filesystem.win32.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.filesystem.win32.x86_64/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %fragmentName
 Bundle-SymbolicName: org.eclipse.core.filesystem.win32.x86_64; singleton:=true
-Bundle-Version: 1.4.200.qualifier
+Bundle-Version: 1.4.300.qualifier
 Bundle-Vendor: %providerName
 Fragment-Host: org.eclipse.core.filesystem;bundle-version="[1.4.0,2.0.0)"
 Bundle-Localization: fragment

--- a/bundles/org.eclipse.core.filesystem.win32.x86_64/pom.xml
+++ b/bundles/org.eclipse.core.filesystem.win32.x86_64/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.core.filesystem.win32.x86_64</artifactId>
-  <version>1.4.200-SNAPSHOT</version>
+  <version>1.4.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/bundles/org.eclipse.core.filesystem/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.core.filesystem/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.eclipse.core.filesystem/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.filesystem/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.filesystem; singleton:=true
-Bundle-Version: 1.9.400.qualifier
+Bundle-Version: 1.9.500.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.equinox.registry;bundle-version="[3.2.0,4.0.0)",

--- a/bundles/org.eclipse.core.resources.releng/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.core.resources.releng/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.eclipse.core.resources.spysupport/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.core.resources.spysupport/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.eclipse.core.resources.spysupport/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.resources.spysupport/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Core Resource Management Spy Support Fragment
 Bundle-SymbolicName: org.eclipse.core.resources.spysupport
-Bundle-Version: 1.5.200.qualifier
+Bundle-Version: 1.5.300.qualifier
 Bundle-Vendor: Eclipse.org
 Fragment-Host: org.eclipse.core.resources;bundle-version="[3.0.0,4.0.0)"
 Export-Package: org.eclipse.core.internal.dtree;x-friends:="org.eclipse.core.tools.resources",

--- a/bundles/org.eclipse.core.resources.win32.x86_64/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.core.resources.win32.x86_64/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.eclipse.core.resources.win32.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.resources.win32.x86_64/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %win32FragmentName
 Bundle-SymbolicName: org.eclipse.core.resources.win32.x86_64;singleton:=true
-Bundle-Version: 3.5.400.qualifier
+Bundle-Version: 3.5.500.qualifier
 Bundle-Vendor: %providerName
 Fragment-Host: org.eclipse.core.resources;bundle-version="[3.5.0,4.0.0)"
 Bundle-Localization: fragment

--- a/bundles/org.eclipse.core.resources.win32.x86_64/pom.xml
+++ b/bundles/org.eclipse.core.resources.win32.x86_64/pom.xml
@@ -15,7 +15,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.core.resources.win32.x86_64</artifactId>
-  <version>3.5.400-SNAPSHOT</version>
+  <version>3.5.500-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/tests/org.eclipse.core.tests.filesystem.feature/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.eclipse.core.tests.filesystem.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/tests/org.eclipse.core.tests.resources.saveparticipant/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.eclipse.core.tests.resources.saveparticipant/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/tests/org.eclipse.core.tests.resources.saveparticipant/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.core.tests.resources.saveparticipant/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Core Tests Save Participant
 Bundle-SymbolicName: org.eclipse.core.tests.resources.saveparticipant; singleton:=true
-Bundle-Version: 3.4.0.qualifier
+Bundle-Version: 3.4.100.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tests.resources.saveparticipant
 Require-Bundle: org.eclipse.core.resources,

--- a/tests/org.eclipse.core.tests.resources.saveparticipant/pom.xml
+++ b/tests/org.eclipse.core.tests.resources.saveparticipant/pom.xml
@@ -24,6 +24,6 @@
   </properties>
 
   <artifactId>org.eclipse.core.tests.resources.saveparticipant</artifactId>
-  <version>3.4.0-SNAPSHOT</version>
+  <version>3.4.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 </project>

--- a/tests/org.eclipse.core.tests.resources.saveparticipant1/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.eclipse.core.tests.resources.saveparticipant1/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/tests/org.eclipse.core.tests.resources.saveparticipant1/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.core.tests.resources.saveparticipant1/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Save Participant 1
 Bundle-Activator: org.eclipse.core.tests.resources.saveparticipant1.SaveParticipant1Plugin
 Bundle-SymbolicName: org.eclipse.core.tests.resources.saveparticipant1
-Bundle-Version: 3.4.0.qualifier
+Bundle-Version: 3.4.100.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tests.resources.saveparticipant1
 Require-Bundle: org.eclipse.core.resources,

--- a/tests/org.eclipse.core.tests.resources.saveparticipant2/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.eclipse.core.tests.resources.saveparticipant2/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/tests/org.eclipse.core.tests.resources.saveparticipant2/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.core.tests.resources.saveparticipant2/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Save Participant 2
 Bundle-SymbolicName: org.eclipse.core.tests.resources.saveparticipant2
-Bundle-Version: 3.4.0.qualifier
+Bundle-Version: 3.4.100.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tests.resources.saveparticipant2
 Require-Bundle: org.eclipse.core.resources,

--- a/tests/org.eclipse.core.tests.resources.saveparticipant3/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.eclipse.core.tests.resources.saveparticipant3/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/tests/org.eclipse.core.tests.resources.saveparticipant3/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.core.tests.resources.saveparticipant3/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Save Participant 3
 Bundle-SymbolicName: org.eclipse.core.tests.resources.saveparticipant3
-Bundle-Version: 3.4.0.qualifier
+Bundle-Version: 3.4.100.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tests.resources.saveparticipant3
 Require-Bundle: org.eclipse.core.resources,


### PR DESCRIPTION
This change was made using the corresponding quickfix to add the missing
project encoding to the corresponding project settings.




