### PR TITLE
AutoBuildOffJob.run() should check if workbench is shutting down #176

### DIFF
--- a/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/events/AutoBuildJob.java
+++ b/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/events/AutoBuildJob.java
@@ -319,6 +319,9 @@ class AutoBuildJob extends Job implements Preferences.IPropertyChangeListener {
 
 		@Override
 		protected IStatus run(IProgressMonitor monitor) {
+			// if the system is shutting down, don't build
+			if (systemBundle.getState() == Bundle.STOPPING)
+				return Status.OK_STATUS;
 			final ISchedulingRule rule = workspace.getRuleFactory().buildRule();
 			try {
 				workspace.prepareOperation(rule, monitor);


### PR DESCRIPTION
This change adjusts AutoBuildOffJob.run() to not do anything if the
platform is shutting down, preventing exceptions during work done by the
job.

Fixes: #176